### PR TITLE
[機能紹介] ノート投稿後の配信処理を JobQueue 化

### DIFF
--- a/packages/backend/src/core/CoreModule.ts
+++ b/packages/backend/src/core/CoreModule.ts
@@ -154,6 +154,7 @@ import { ApQuestionService } from './activitypub/models/ApQuestionService.js';
 
 import { QueueService } from './QueueService.js';
 import { LoggerService } from './LoggerService.js';
+import { NoteNotificationManagerService } from './NoteNotificationManagerService.js';
 import type { Provider } from '@nestjs/common';
 
 //#region 文字列ベースでのinjection用(循環参照対応のため)
@@ -186,6 +187,7 @@ const $MfmService: Provider = { provide: 'MfmService', useExisting: MfmService }
 const $ModerationLogService: Provider = { provide: 'ModerationLogService', useExisting: ModerationLogService };
 const $NoteCreateService: Provider = { provide: 'NoteCreateService', useExisting: NoteCreateService };
 const $NoteDeleteService: Provider = { provide: 'NoteDeleteService', useExisting: NoteDeleteService };
+const $NoteNotificationManagerService: Provider = { provide: 'NoteNotificationManagerService', useExisting: NoteNotificationManagerService };
 const $NotePiningService: Provider = { provide: 'NotePiningService', useExisting: NotePiningService };
 const $NoteDraftService: Provider = { provide: 'NoteDraftService', useExisting: NoteDraftService };
 const $NotificationService: Provider = { provide: 'NotificationService', useExisting: NotificationService };
@@ -338,6 +340,7 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		ModerationLogService,
 		NoteCreateService,
 		NoteDeleteService,
+		NoteNotificationManagerService,
 		NotePiningService,
 		NoteDraftService,
 		NotificationService,
@@ -488,6 +491,7 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		$ModerationLogService,
 		$NoteCreateService,
 		$NoteDeleteService,
+		$NoteNotificationManagerService,
 		$NotePiningService,
 		$NoteDraftService,
 		$NotificationService,
@@ -637,6 +641,7 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		ModerationLogService,
 		NoteCreateService,
 		NoteDeleteService,
+		NoteNotificationManagerService,
 		NotePiningService,
 		NoteDraftService,
 		NotificationService,
@@ -786,6 +791,7 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		$ModerationLogService,
 		$NoteCreateService,
 		$NoteDeleteService,
+		$NoteNotificationManagerService,
 		$NotePiningService,
 		$NoteDraftService,
 		$NotificationService,

--- a/packages/backend/src/core/NoteCreateService.ts
+++ b/packages/backend/src/core/NoteCreateService.ts
@@ -3,162 +3,39 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { setImmediate } from 'node:timers/promises';
 import * as mfm from 'mfm-js';
-import { In, DataSource, IsNull, LessThan } from 'typeorm';
-import * as Redis from 'ioredis';
-import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
+import { In, DataSource } from 'typeorm';
+import { Inject, Injectable } from '@nestjs/common';
 import { extractMentions } from '@/misc/extract-mentions.js';
 import { extractCustomEmojisFromMfm } from '@/misc/extract-custom-emojis-from-mfm.js';
 import { extractHashtags } from '@/misc/extract-hashtags.js';
 import type { IMentionedRemoteUsers } from '@/models/Note.js';
 import { MiNote } from '@/models/Note.js';
-import type { BlockingsRepository, ChannelFollowingsRepository, ChannelsRepository, DriveFilesRepository, FollowingsRepository, InstancesRepository, MiFollowing, MiMeta, MutingsRepository, NotesRepository, NoteThreadMutingsRepository, UserListMembershipsRepository, UserProfilesRepository, UsersRepository } from '@/models/_.js';
+import type { BlockingsRepository, ChannelsRepository, DriveFilesRepository, MiMeta, NotesRepository, NoteThreadMutingsRepository, UserProfilesRepository, UsersRepository } from '@/models/_.js';
 import type { MiDriveFile } from '@/models/DriveFile.js';
 import type { MiApp } from '@/models/App.js';
 import { concat } from '@/misc/prelude/array.js';
 import { IdService } from '@/core/IdService.js';
-import type { MiUser, MiLocalUser, MiRemoteUser } from '@/models/User.js';
+import type { MiUser } from '@/models/User.js';
 import type { IPoll } from '@/models/Poll.js';
 import { MiPoll } from '@/models/Poll.js';
 import { isDuplicateKeyValueError } from '@/misc/is-duplicate-key-value-error.js';
 import type { MiChannel } from '@/models/Channel.js';
 import { normalizeForSearch } from '@/misc/normalize-for-search.js';
-import { RelayService } from '@/core/RelayService.js';
-import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { DI } from '@/di-symbols.js';
 import type { Config } from '@/config.js';
-import NotesChart from '@/core/chart/charts/notes.js';
-import PerUserNotesChart from '@/core/chart/charts/per-user-notes.js';
-import InstanceChart from '@/core/chart/charts/instance.js';
-import ActiveUsersChart from '@/core/chart/charts/active-users.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
-import { NotificationService } from '@/core/NotificationService.js';
-import { UserWebhookService } from '@/core/UserWebhookService.js';
-import { HashtagService } from '@/core/HashtagService.js';
-import { AntennaService } from '@/core/AntennaService.js';
 import { QueueService } from '@/core/QueueService.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
-import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
-import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
 import { RemoteUserResolveService } from '@/core/RemoteUserResolveService.js';
 import { bindThis } from '@/decorators.js';
 import { DB_MAX_NOTE_TEXT_LENGTH } from '@/const.js';
 import { RoleService } from '@/core/RoleService.js';
-import { SearchService } from '@/core/SearchService.js';
-import { FeaturedService } from '@/core/FeaturedService.js';
-import { FanoutTimelineService } from '@/core/FanoutTimelineService.js';
 import { UtilityService } from '@/core/UtilityService.js';
 import { UserBlockingService } from '@/core/UserBlockingService.js';
-import { isReply } from '@/misc/is-reply.js';
-import { trackPromise } from '@/misc/promise-tracker.js';
 import { IdentifiableError } from '@/misc/identifiable-error.js';
-import { CollapsedQueue } from '@/misc/collapsed-queue.js';
-import { CacheService } from '@/core/CacheService.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
-
-type NotificationType = 'reply' | 'renote' | 'quote' | 'mention';
-
-class NotificationManager {
-	private notifier: { id: MiUser['id']; };
-	private note: MiNote;
-	private queue: Map<MiLocalUser['id'], {
-		target: MiLocalUser['id'];
-		reason: NotificationType;
-	}>;
-
-	constructor(
-		private mutingsRepository: MutingsRepository,
-		private notificationService: NotificationService,
-		private followingsRepository: FollowingsRepository,
-		notifier: { id: MiUser['id']; },
-		note: MiNote,
-	) {
-		this.notifier = notifier;
-		this.note = note;
-		this.queue = new Map();
-	}
-
-	@bindThis
-	public push(notifiee: MiLocalUser['id'], reason: NotificationType) {
-		// 自分自身へは通知しない
-		if (this.notifier.id === notifiee) return;
-
-		const exist = this.queue.get(notifiee);
-
-		if (exist) {
-			// 「メンションされているかつ返信されている」場合は、メンションとしての通知ではなく返信としての通知にする
-			if (reason !== 'mention') {
-				exist.reason = reason;
-			}
-		} else {
-			this.queue.set(notifiee, {
-				reason: reason,
-				target: notifiee,
-			});
-		}
-	}
-
-	@bindThis
-	public async notify() {
-		if (this.queue.size === 0) {
-			return;
-		}
-
-		let visibleUserIds: Set<MiUser['id']> | null;
-
-		switch (this.note.visibility) {
-			case 'public':
-			case 'home':
-				visibleUserIds = null;
-				break;
-
-			case 'specified':
-				visibleUserIds = new Set(this.note.visibleUserIds);
-				break;
-
-			case 'followers': {
-			// TODO: フォロワー限定ノートにフォロワーではない人がメンションされた場合通知されるのが正しい挙動なのか確認（一部に挙動の不一致がありそう）。現状は通知されるためフィルタしない
-			// 	const targetUserIds = this.queue.map(x => x.target);
-			// 	const followers = await this.followingsRepository.find({
-			// 		where: {
-			// 			followeeId: this.note.userId,
-			// 			followerId: In(targetUserIds),
-			// 			isFollowerHibernated: false,
-			// 		},
-			// 		select: ['followerId'],
-			// 	});
-			// 	visibleUserIds = new Set(followers.map(f => f.followerId));
-				visibleUserIds = null;
-				break;
-			}
-
-			default:
-				visibleUserIds = new Set();
-				break;
-		}
-
-		for (const x of this.queue.values()) {
-			const isVisibleToTarget = visibleUserIds === null || visibleUserIds.has(x.target);
-
-			if (!isVisibleToTarget) {
-				continue;
-			}
-
-			if (x.reason === 'renote') {
-				this.notificationService.createNotification(x.target, 'renote', {
-					noteId: this.note.id,
-					targetNoteId: this.note.renoteId!,
-				}, this.notifier.id);
-			} else {
-				this.notificationService.createNotification(x.target, x.reason, {
-					noteId: this.note.id,
-				}, this.notifier.id);
-			}
-		}
-	}
-}
 
 type MinimumUser = {
 	id: MiUser['id'];
@@ -190,10 +67,7 @@ type Option = {
 };
 
 @Injectable()
-export class NoteCreateService implements OnApplicationShutdown {
-	#shutdownController = new AbortController();
-	private updateNotesCountQueue: CollapsedQueue<MiNote['id'], number>;
-
+export class NoteCreateService {
 	constructor(
 		@Inject(DI.config)
 		private config: Config,
@@ -204,38 +78,17 @@ export class NoteCreateService implements OnApplicationShutdown {
 		@Inject(DI.db)
 		private db: DataSource,
 
-		@Inject(DI.redisForTimelines)
-		private redisForTimelines: Redis.Redis,
-
 		@Inject(DI.usersRepository)
 		private usersRepository: UsersRepository,
 
 		@Inject(DI.notesRepository)
 		private notesRepository: NotesRepository,
 
-		@Inject(DI.mutingsRepository)
-		private mutingsRepository: MutingsRepository,
-
-		@Inject(DI.instancesRepository)
-		private instancesRepository: InstancesRepository,
-
 		@Inject(DI.userProfilesRepository)
 		private userProfilesRepository: UserProfilesRepository,
 
-		@Inject(DI.userListMembershipsRepository)
-		private userListMembershipsRepository: UserListMembershipsRepository,
-
 		@Inject(DI.channelsRepository)
 		private channelsRepository: ChannelsRepository,
-
-		@Inject(DI.noteThreadMutingsRepository)
-		private noteThreadMutingsRepository: NoteThreadMutingsRepository,
-
-		@Inject(DI.followingsRepository)
-		private followingsRepository: FollowingsRepository,
-
-		@Inject(DI.channelFollowingsRepository)
-		private channelFollowingsRepository: ChannelFollowingsRepository,
 
 		@Inject(DI.blockingsRepository)
 		private blockingsRepository: BlockingsRepository,
@@ -243,33 +96,19 @@ export class NoteCreateService implements OnApplicationShutdown {
 		@Inject(DI.driveFilesRepository)
 		private driveFilesRepository: DriveFilesRepository,
 
+		@Inject(DI.noteThreadMutingsRepository)
+		private noteThreadMutingsRepository: NoteThreadMutingsRepository,
+
 		private userEntityService: UserEntityService,
 		private noteEntityService: NoteEntityService,
-		private idService: IdService,
 		private globalEventService: GlobalEventService,
+		private idService: IdService,
 		private queueService: QueueService,
-		private fanoutTimelineService: FanoutTimelineService,
-		private notificationService: NotificationService,
-		private relayService: RelayService,
-		private federatedInstanceService: FederatedInstanceService,
-		private hashtagService: HashtagService,
-		private antennaService: AntennaService,
-		private webhookService: UserWebhookService,
-		private featuredService: FeaturedService,
 		private remoteUserResolveService: RemoteUserResolveService,
-		private apDeliverManagerService: ApDeliverManagerService,
-		private apRendererService: ApRendererService,
 		private roleService: RoleService,
-		private searchService: SearchService,
-		private notesChart: NotesChart,
-		private perUserNotesChart: PerUserNotesChart,
-		private activeUsersChart: ActiveUsersChart,
-		private instanceChart: InstanceChart,
 		private utilityService: UtilityService,
 		private userBlockingService: UserBlockingService,
-		private cacheService: CacheService,
 	) {
-		this.updateNotesCountQueue = new CollapsedQueue(process.env.NODE_ENV !== 'test' ? 60 * 1000 * 5 : 0, this.collapseNotesCount, this.performUpdateNotesCount);
 	}
 
 	@bindThis
@@ -604,10 +443,43 @@ export class NoteCreateService implements OnApplicationShutdown {
 
 		const note = await this.insertNote(user, data, tags, emojis, mentionedUsers);
 
-		setImmediate('post created', { signal: this.#shutdownController.signal }).then(
-			() => this.postNoteCreated(note, user, data, silent, tags!, mentionedUsers!),
-			() => { /* aborted, ignore this */ },
-		);
+		// Streaming events must fire immediately (before job queue) to satisfy realtime latency
+		if (!silent) {
+			const noteObj = await this.noteEntityService.pack(note, null, { skipHide: true, withReactionAndUserPairCache: true });
+			this.globalEventService.publishNotesStream(noteObj);
+			this.roleService.addNoteToRoleTimeline(noteObj);
+
+			if (data.reply && data.reply.userHost === null) {
+				const threadId = note.threadId ?? data.reply.id;
+				const isThreadMuted = await this.noteThreadMutingsRepository.exists({
+					where: { userId: data.reply.userId, threadId },
+				});
+				if (!isThreadMuted) {
+					this.globalEventService.publishMainStream(data.reply.userId, 'reply', noteObj);
+				}
+			}
+
+			if (data.renote && (user.id !== data.renote.userId) && data.renote.userHost === null) {
+				this.globalEventService.publishMainStream(data.renote.userId, 'renote', noteObj);
+			}
+
+			const localMentionedUsers = mentionedUsers.filter(u => this.userEntityService.isLocalUser(u));
+			if (localMentionedUsers.length > 0) {
+				const threadId = note.threadId ?? note.id;
+				const muted = await this.noteThreadMutingsRepository.find({
+					where: { threadId, userId: In(localMentionedUsers.map(u => u.id)) },
+					select: ['userId'],
+				});
+				const mutedUserIds = new Set(muted.map(x => x.userId));
+				for (const u of localMentionedUsers) {
+					if (mutedUserIds.has(u.id)) continue;
+					const detailPackedNote = await this.noteEntityService.pack(note, u, { detail: true });
+					this.globalEventService.publishMainStream(u.id, 'mention', detailPackedNote);
+				}
+			}
+		}
+
+		this.queueService.notePost(note.id, silent);
 
 		return note;
 	}
@@ -716,196 +588,6 @@ export class NoteCreateService implements OnApplicationShutdown {
 	}
 
 	@bindThis
-	private async postNoteCreated(note: MiNote, user: {
-		id: MiUser['id'];
-		username: MiUser['username'];
-		host: MiUser['host'];
-		isBot: MiUser['isBot'];
-	}, data: Option, silent: boolean, tags: string[], mentionedUsers: MinimumUser[]) {
-		this.notesChart.update(note, true);
-		if (note.visibility !== 'specified' && (this.meta.enableChartsForRemoteUser || (user.host == null))) {
-			this.perUserNotesChart.update(user, note, true);
-		}
-
-		// Register host
-		if (this.meta.enableStatsForFederatedInstances) {
-			if (this.userEntityService.isRemoteUser(user)) {
-				this.federatedInstanceService.fetchOrRegister(user.host).then(async i => {
-					this.updateNotesCountQueue.enqueue(i.id, 1);
-					if (this.meta.enableChartsForFederatedInstances) {
-						this.instanceChart.updateNote(i.host, note, true);
-					}
-				});
-			}
-		}
-
-		// ハッシュタグ更新
-		if (data.visibility === 'public' || data.visibility === 'home') {
-			this.hashtagService.updateHashtags(user, tags);
-		}
-
-		// Increment notes count (user)
-		this.incNotesCountOfUser(user);
-
-		this.pushToTl(note, user);
-
-		this.antennaService.addNoteToAntennas({
-			...note,
-			channel: data.channel ?? null,
-		}, user);
-
-		if (data.reply) {
-			this.saveReply(data.reply, note);
-		}
-
-		if (data.reply == null) {
-			// TODO: キャッシュ
-			this.followingsRepository.findBy({
-				followeeId: user.id,
-				notify: 'normal',
-			}).then(async followings => {
-				if (note.visibility !== 'specified') {
-					const isPureRenote = this.isRenote(data) && !this.isQuote(data) ? true : false;
-					for (const following of followings) {
-						// TODO: ワードミュート考慮
-						let isRenoteMuted = false;
-						if (isPureRenote) {
-							const userIdsWhoMeMutingRenotes = await this.cacheService.renoteMutingsCache.fetch(following.followerId);
-							isRenoteMuted = userIdsWhoMeMutingRenotes.has(user.id);
-						}
-						if (!isRenoteMuted) {
-							this.notificationService.createNotification(following.followerId, 'note', {
-								noteId: note.id,
-							}, user.id);
-						}
-					}
-				}
-			});
-		}
-
-		if (data.renote && data.renote.userId !== user.id && !user.isBot) {
-			this.incRenoteCount(data.renote);
-		}
-
-		if (data.poll && data.poll.expiresAt) {
-			const delay = data.poll.expiresAt.getTime() - Date.now();
-			this.queueService.endedPollNotification(note.id, delay);
-		}
-
-		if (!silent) {
-			if (this.userEntityService.isLocalUser(user)) this.activeUsersChart.write(user);
-
-			// Pack the note
-			const noteObj = await this.noteEntityService.pack(note, null, { skipHide: true, withReactionAndUserPairCache: true });
-
-			this.globalEventService.publishNotesStream(noteObj);
-
-			this.roleService.addNoteToRoleTimeline(noteObj);
-
-			this.webhookService.enqueueUserWebhook(user.id, 'note', { note: noteObj });
-
-			const nm = new NotificationManager(this.mutingsRepository, this.notificationService, this.followingsRepository, user, note);
-
-			await this.createMentionedEvents(mentionedUsers, note, nm);
-
-			// If has in reply to note
-			if (data.reply) {
-				// 通知
-				if (data.reply.userHost === null) {
-					const isThreadMuted = await this.noteThreadMutingsRepository.exists({
-						where: {
-							userId: data.reply.userId,
-							threadId: data.reply.threadId ?? data.reply.id,
-						},
-					});
-
-					if (!isThreadMuted) {
-						nm.push(data.reply.userId, 'reply');
-						this.globalEventService.publishMainStream(data.reply.userId, 'reply', noteObj);
-						this.webhookService.enqueueUserWebhook(data.reply.userId, 'reply', { note: noteObj });
-					}
-				}
-			}
-
-			// If it is renote
-			if (this.isRenote(data)) {
-				const type = this.isQuote(data) ? 'quote' : 'renote';
-
-				// Notify
-				if (data.renote.userHost === null) {
-					nm.push(data.renote.userId, type);
-				}
-
-				// Publish event
-				if ((user.id !== data.renote.userId) && data.renote.userHost === null) {
-					this.globalEventService.publishMainStream(data.renote.userId, 'renote', noteObj);
-					this.webhookService.enqueueUserWebhook(data.renote.userId, 'renote', { note: noteObj });
-				}
-			}
-
-			nm.notify();
-
-			//#region AP deliver
-			if (!data.localOnly && this.userEntityService.isLocalUser(user)) {
-				(async () => {
-					const noteActivity = await this.renderNoteOrRenoteActivity(data, note);
-					const dm = this.apDeliverManagerService.createDeliverManager(user, noteActivity);
-
-					// メンションされたリモートユーザーに配送
-					for (const u of mentionedUsers.filter(u => this.userEntityService.isRemoteUser(u))) {
-						dm.addDirectRecipe(u as MiRemoteUser);
-					}
-
-					// 投稿がリプライかつ投稿者がローカルユーザーかつリプライ先の投稿の投稿者がリモートユーザーなら配送
-					if (data.reply && data.reply.userHost !== null) {
-						const u = await this.usersRepository.findOneBy({ id: data.reply.userId });
-						if (u && this.userEntityService.isRemoteUser(u)) dm.addDirectRecipe(u);
-					}
-
-					// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
-					if (data.renote && data.renote.userHost !== null) {
-						const u = await this.usersRepository.findOneBy({ id: data.renote.userId });
-						if (u && this.userEntityService.isRemoteUser(u)) dm.addDirectRecipe(u);
-					}
-
-					// フォロワーに配送
-					if (['public', 'home', 'followers'].includes(note.visibility)) {
-						dm.addFollowersRecipe();
-					}
-
-					if (['public'].includes(note.visibility)) {
-						this.relayService.deliverToRelays(user, noteActivity);
-					}
-
-					trackPromise(dm.execute());
-				})();
-			}
-			//#endregion
-		}
-
-		if (data.channel) {
-			this.channelsRepository.increment({ id: data.channel.id }, 'notesCount', 1);
-			this.channelsRepository.update(data.channel.id, {
-				lastNotedAt: new Date(),
-			});
-
-			this.notesRepository.countBy({
-				userId: user.id,
-				channelId: data.channel.id,
-			}).then(count => {
-				// この処理が行われるのはノート作成後なので、ノートが一つしかなかったら最初の投稿だと判断できる
-				// TODO: とはいえノートを削除して何回も投稿すればその分だけインクリメントされる雑さもあるのでどうにかしたい
-				if (count === 1) {
-					this.channelsRepository.increment({ id: data.channel!.id }, 'usersCount', 1);
-				}
-			});
-		}
-
-		// Register to search database
-		this.index(note);
-	}
-
-	@bindThis
 	private isRenote(note: Option): note is Option & { renote: MiNote } {
 		return note.renote != null;
 	}
@@ -920,90 +602,6 @@ export class NoteCreateService implements OnApplicationShutdown {
 			note.cw != null ||
 			note.poll != null ||
 			(note.files != null && note.files.length > 0);
-	}
-
-	@bindThis
-	private incRenoteCount(renote: MiNote) {
-		this.notesRepository.createQueryBuilder().update()
-			.set({
-				renoteCount: () => '"renoteCount" + 1',
-			})
-			.where('id = :id', { id: renote.id })
-			.execute();
-
-		// 30%の確率、3日以内に投稿されたノートの場合ハイライト用ランキング更新
-		if (Math.random() < 0.3 && (Date.now() - this.idService.parse(renote.id).date.getTime()) < 1000 * 60 * 60 * 24 * 3) {
-			if (renote.channelId != null) {
-				if (renote.replyId == null) {
-					this.featuredService.updateInChannelNotesRanking(renote.channelId, renote.id, 5);
-				}
-			} else {
-				if (renote.visibility === 'public' && renote.userHost == null && renote.replyId == null) {
-					this.featuredService.updateGlobalNotesRanking(renote.id, 5);
-					this.featuredService.updatePerUserNotesRanking(renote.userId, renote.id, 5);
-				}
-			}
-		}
-	}
-
-	@bindThis
-	private async createMentionedEvents(mentionedUsers: MinimumUser[], note: MiNote, nm: NotificationManager) {
-		for (const u of mentionedUsers.filter(u => this.userEntityService.isLocalUser(u))) {
-			const isThreadMuted = await this.noteThreadMutingsRepository.exists({
-				where: {
-					userId: u.id,
-					threadId: note.threadId ?? note.id,
-				},
-			});
-
-			if (isThreadMuted) {
-				continue;
-			}
-
-			const detailPackedNote = await this.noteEntityService.pack(note, u, {
-				detail: true,
-			});
-
-			this.globalEventService.publishMainStream(u.id, 'mention', detailPackedNote);
-			this.webhookService.enqueueUserWebhook(u.id, 'mention', { note: detailPackedNote });
-
-			// Create notification
-			nm.push(u.id, 'mention');
-		}
-	}
-
-	@bindThis
-	private saveReply(reply: MiNote, note: MiNote) {
-		this.notesRepository.increment({ id: reply.id }, 'repliesCount', 1);
-	}
-
-	@bindThis
-	private async renderNoteOrRenoteActivity(data: Option, note: MiNote) {
-		if (data.localOnly) return null;
-
-		const content = this.isRenote(data) && !this.isQuote(data)
-			? this.apRendererService.renderAnnounce(data.renote.uri ? data.renote.uri : `${this.config.url}/notes/${data.renote.id}`, note)
-			: this.apRendererService.renderCreate(await this.apRendererService.renderNote(note, false), note);
-
-		return this.apRendererService.addContext(content);
-	}
-
-	@bindThis
-	private index(note: MiNote) {
-		if (note.text == null && note.cw == null) return;
-
-		this.searchService.indexNote(note);
-	}
-
-	@bindThis
-	private incNotesCountOfUser(user: { id: MiUser['id']; }) {
-		this.usersRepository.createQueryBuilder().update()
-			.set({
-				updatedAt: new Date(),
-				notesCount: () => '"notesCount" + 1',
-			})
-			.where('id = :id', { id: user.id })
-			.execute();
 	}
 
 	@bindThis
@@ -1023,172 +621,6 @@ export class NoteCreateService implements OnApplicationShutdown {
 		return mentionedUsers;
 	}
 
-	@bindThis
-	private async pushToTl(note: MiNote, user: { id: MiUser['id']; host: MiUser['host']; }) {
-		if (!this.meta.enableFanoutTimeline) return;
-
-		const r = this.redisForTimelines.pipeline();
-
-		if (note.channelId) {
-			this.fanoutTimelineService.push(`channelTimeline:${note.channelId}`, note.id, this.config.perChannelMaxNoteCacheCount, r);
-
-			this.fanoutTimelineService.push(`userTimelineWithChannel:${user.id}`, note.id, note.userHost == null ? this.meta.perLocalUserUserTimelineCacheMax : this.meta.perRemoteUserUserTimelineCacheMax, r);
-
-			const channelFollowings = await this.channelFollowingsRepository.find({
-				where: {
-					followeeId: note.channelId,
-				},
-				select: ['followerId'],
-			});
-
-			for (const channelFollowing of channelFollowings) {
-				this.fanoutTimelineService.push(`homeTimeline:${channelFollowing.followerId}`, note.id, this.meta.perUserHomeTimelineCacheMax, r);
-				if (note.fileIds.length > 0) {
-					this.fanoutTimelineService.push(`homeTimelineWithFiles:${channelFollowing.followerId}`, note.id, this.meta.perUserHomeTimelineCacheMax / 2, r);
-				}
-			}
-		} else {
-			// TODO: キャッシュ？
-			// eslint-disable-next-line prefer-const
-			let [followings, userListMemberships] = await Promise.all([
-				this.followingsRepository.find({
-					where: {
-						followeeId: user.id,
-						followerHost: IsNull(),
-						isFollowerHibernated: false,
-					},
-					select: ['followerId', 'withReplies'],
-				}),
-				this.userListMembershipsRepository.find({
-					where: {
-						userId: user.id,
-					},
-					select: ['userListId', 'userListUserId', 'withReplies'],
-				}),
-			]);
-
-			if (note.visibility === 'followers') {
-				// TODO: 重そうだから何とかしたい Set 使う？
-				userListMemberships = userListMemberships.filter(x => x.userListUserId === user.id || followings.some(f => f.followerId === x.userListUserId));
-			}
-
-			// TODO: あまりにも数が多いと redisPipeline.exec に失敗する(理由は不明)ため、3万件程度を目安に分割して実行するようにする
-			for (const following of followings) {
-				// 基本的にvisibleUserIdsには自身のidが含まれている前提であること
-				if (note.visibility === 'specified' && !note.visibleUserIds.some(v => v === following.followerId)) continue;
-
-				// 「自分自身への返信 or そのフォロワーへの返信」のどちらでもない場合
-				if (isReply(note, following.followerId)) {
-					if (!following.withReplies) continue;
-				}
-
-				this.fanoutTimelineService.push(`homeTimeline:${following.followerId}`, note.id, this.meta.perUserHomeTimelineCacheMax, r);
-				if (note.fileIds.length > 0) {
-					this.fanoutTimelineService.push(`homeTimelineWithFiles:${following.followerId}`, note.id, this.meta.perUserHomeTimelineCacheMax / 2, r);
-				}
-			}
-
-			for (const userListMembership of userListMemberships) {
-				// ダイレクトのとき、そのリストが対象外のユーザーの場合
-				if (
-					note.visibility === 'specified' &&
-					note.userId !== userListMembership.userListUserId &&
-					!note.visibleUserIds.some(v => v === userListMembership.userListUserId)
-				) continue;
-
-				// 「自分自身への返信 or そのリストの作成者への返信」のどちらでもない場合
-				if (isReply(note, userListMembership.userListUserId)) {
-					if (!userListMembership.withReplies) continue;
-				}
-
-				this.fanoutTimelineService.push(`userListTimeline:${userListMembership.userListId}`, note.id, this.meta.perUserListTimelineCacheMax, r);
-				if (note.fileIds.length > 0) {
-					this.fanoutTimelineService.push(`userListTimelineWithFiles:${userListMembership.userListId}`, note.id, this.meta.perUserListTimelineCacheMax / 2, r);
-				}
-			}
-
-			// 自分自身のHTL
-			if (note.userHost == null) {
-				if (note.visibility !== 'specified' || !note.visibleUserIds.some(v => v === user.id)) {
-					this.fanoutTimelineService.push(`homeTimeline:${user.id}`, note.id, this.meta.perUserHomeTimelineCacheMax, r);
-					if (note.fileIds.length > 0) {
-						this.fanoutTimelineService.push(`homeTimelineWithFiles:${user.id}`, note.id, this.meta.perUserHomeTimelineCacheMax / 2, r);
-					}
-				}
-			}
-
-			// 自分自身以外への返信
-			if (isReply(note)) {
-				this.fanoutTimelineService.push(`userTimelineWithReplies:${user.id}`, note.id, note.userHost == null ? this.meta.perLocalUserUserTimelineCacheMax : this.meta.perRemoteUserUserTimelineCacheMax, r);
-
-				if (note.visibility === 'public' && note.userHost == null) {
-					this.fanoutTimelineService.push('localTimelineWithReplies', note.id, 300, r);
-					if (note.replyUserHost == null) {
-						this.fanoutTimelineService.push(`localTimelineWithReplyTo:${note.replyUserId}`, note.id, 300 / 10, r);
-					}
-				}
-			} else {
-				this.fanoutTimelineService.push(`userTimeline:${user.id}`, note.id, note.userHost == null ? this.meta.perLocalUserUserTimelineCacheMax : this.meta.perRemoteUserUserTimelineCacheMax, r);
-				if (note.fileIds.length > 0) {
-					this.fanoutTimelineService.push(`userTimelineWithFiles:${user.id}`, note.id, note.userHost == null ? this.meta.perLocalUserUserTimelineCacheMax / 2 : this.meta.perRemoteUserUserTimelineCacheMax / 2, r);
-				}
-
-				if (note.visibility === 'public' && note.userHost == null) {
-					this.fanoutTimelineService.push('localTimeline', note.id, 1000, r);
-					if (note.fileIds.length > 0) {
-						this.fanoutTimelineService.push('localTimelineWithFiles', note.id, 500, r);
-					}
-				}
-			}
-
-			if (Math.random() < 0.1) {
-				process.nextTick(() => {
-					this.checkHibernation(followings);
-				});
-			}
-		}
-
-		r.exec();
-	}
-
-	@bindThis
-	public async checkHibernation(followings: MiFollowing[]) {
-		if (followings.length === 0) return;
-
-		const shuffle = (array: MiFollowing[]) => {
-			for (let i = array.length - 1; i > 0; i--) {
-				const j = Math.floor(Math.random() * (i + 1));
-				[array[i], array[j]] = [array[j], array[i]];
-			}
-			return array;
-		};
-
-		// ランダムに最大1000件サンプリング
-		const samples = shuffle(followings).slice(0, Math.min(followings.length, 1000));
-
-		const hibernatedUsers = await this.usersRepository.find({
-			where: {
-				id: In(samples.map(x => x.followerId)),
-				lastActiveDate: LessThan(new Date(Date.now() - (1000 * 60 * 60 * 24 * 50))),
-			},
-			select: ['id'],
-		});
-
-		if (hibernatedUsers.length > 0) {
-			this.usersRepository.update({
-				id: In(hibernatedUsers.map(x => x.id)),
-			}, {
-				isHibernated: true,
-			});
-
-			this.followingsRepository.update({
-				followerId: In(hibernatedUsers.map(x => x.id)),
-			}, {
-				isFollowerHibernated: true,
-			});
-		}
-	}
-
 	public checkProhibitedWordsContain(content: Parameters<UtilityService['concatNoteContentsForKeyWordCheck']>[0], prohibitedWords?: string[]) {
 		if (prohibitedWords == null) {
 			prohibitedWords = this.meta.prohibitedWords;
@@ -1204,26 +636,5 @@ export class NoteCreateService implements OnApplicationShutdown {
 		}
 
 		return false;
-	}
-
-	@bindThis
-	private collapseNotesCount(oldValue: number, newValue: number) {
-		return oldValue + newValue;
-	}
-
-	@bindThis
-	private async performUpdateNotesCount(id: MiNote['id'], incrBy: number) {
-		await this.instancesRepository.increment({ id: id }, 'notesCount', incrBy);
-	}
-
-	@bindThis
-	public async dispose(): Promise<void> {
-		this.#shutdownController.abort();
-		await this.updateNotesCountQueue.performAllNow();
-	}
-
-	@bindThis
-	public async onApplicationShutdown(signal?: string | undefined): Promise<void> {
-		await this.dispose();
 	}
 }

--- a/packages/backend/src/core/NoteDeleteService.ts
+++ b/packages/backend/src/core/NoteDeleteService.ts
@@ -8,20 +8,15 @@ import { Injectable, Inject } from '@nestjs/common';
 import type { MiUser, MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import type { MiNote, IMentionedRemoteUsers } from '@/models/Note.js';
 import type { InstancesRepository, MiMeta, NotesRepository, UsersRepository } from '@/models/_.js';
-import { RelayService } from '@/core/RelayService.js';
-import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { DI } from '@/di-symbols.js';
 import type { Config } from '@/config.js';
-import NotesChart from '@/core/chart/charts/notes.js';
-import PerUserNotesChart from '@/core/chart/charts/per-user-notes.js';
-import InstanceChart from '@/core/chart/charts/instance.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
-import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { bindThis } from '@/decorators.js';
 import { SearchService } from '@/core/SearchService.js';
 import { ModerationLogService } from '@/core/ModerationLogService.js';
+import { QueueService } from '@/core/QueueService.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
 
 @Injectable()
@@ -39,20 +34,12 @@ export class NoteDeleteService {
 		@Inject(DI.notesRepository)
 		private notesRepository: NotesRepository,
 
-		@Inject(DI.instancesRepository)
-		private instancesRepository: InstancesRepository,
-
 		private userEntityService: UserEntityService,
 		private globalEventService: GlobalEventService,
-		private relayService: RelayService,
-		private federatedInstanceService: FederatedInstanceService,
 		private apRendererService: ApRendererService,
-		private apDeliverManagerService: ApDeliverManagerService,
 		private searchService: SearchService,
 		private moderationLogService: ModerationLogService,
-		private notesChart: NotesChart,
-		private perUserNotesChart: PerUserNotesChart,
-		private instanceChart: InstanceChart,
+		private queueService: QueueService,
 	) {}
 
 	/**
@@ -67,45 +54,30 @@ export class NoteDeleteService {
 			await this.notesRepository.decrement({ id: note.replyId }, 'repliesCount', 1);
 		}
 
+		// AP 配信用コンテンツをノート削除前に生成 (削除後は renote 等の参照ができない)
+		let apContent: any | null = null;
+		let apRecipientIds: string[] = [];
+
+		if (!quiet && this.userEntityService.isLocalUser(user) && !note.localOnly) {
+			let renote: MiNote | null = null;
+			if (isRenote(note) && !isQuote(note)) {
+				renote = await this.notesRepository.findOneBy({ id: note.renoteId });
+			}
+
+			apContent = this.apRendererService.addContext(renote
+				? this.apRendererService.renderUndo(this.apRendererService.renderAnnounce(renote.uri ?? `${this.config.url}/notes/${renote.id}`, note), user)
+				: this.apRendererService.renderDelete(this.apRendererService.renderTombstone(`${this.config.url}/notes/${note.id}`), user));
+
+			const [mentionedRemoteUsers, renotedOrRepliedRemoteUsers] = await Promise.all([
+				this.getMentionedRemoteUsers(note),
+				this.getRenotedOrRepliedRemoteUsers(note),
+			]);
+			const allRecipients = [...mentionedRemoteUsers, ...renotedOrRepliedRemoteUsers];
+			apRecipientIds = [...new Set(allRecipients.map(u => u.id))];
+		}
+
 		if (!quiet) {
-			this.globalEventService.publishNoteStream(note, 'deleted', {
-				deletedAt: deletedAt,
-			});
-
-			//#region ローカルの投稿なら削除アクティビティを配送
-			if (this.userEntityService.isLocalUser(user) && !note.localOnly) {
-				let renote: MiNote | null = null;
-
-				// if deleted note is renote
-				if (isRenote(note) && !isQuote(note)) {
-					renote = await this.notesRepository.findOneBy({
-						id: note.renoteId,
-					});
-				}
-
-				const content = this.apRendererService.addContext(renote
-					? this.apRendererService.renderUndo(this.apRendererService.renderAnnounce(renote.uri ?? `${this.config.url}/notes/${renote.id}`, note), user)
-					: this.apRendererService.renderDelete(this.apRendererService.renderTombstone(`${this.config.url}/notes/${note.id}`), user));
-
-				this.deliverToConcerned(user, note, content);
-			}
-			//#endregion
-
-			this.notesChart.update(note, false);
-			if (this.meta.enableChartsForRemoteUser || (user.host == null)) {
-				this.perUserNotesChart.update(user, note, false);
-			}
-
-			if (this.meta.enableStatsForFederatedInstances) {
-				if (this.userEntityService.isRemoteUser(user)) {
-					this.federatedInstanceService.fetchOrRegister(user.host).then(async i => {
-						this.instancesRepository.decrement({ id: i.id }, 'notesCount', 1);
-						if (this.meta.enableChartsForFederatedInstances) {
-							this.instanceChart.updateNote(i.host, note, false);
-						}
-					});
-				}
-			}
+			this.globalEventService.publishNoteStream(note, 'deleted', { deletedAt });
 		}
 
 		this.searchService.unindexNote(note);
@@ -116,41 +88,54 @@ export class NoteDeleteService {
 		});
 
 		if (deleter && (note.userId !== deleter.id)) {
-			const user = await this.usersRepository.findOneByOrFail({ id: note.userId });
+			const noteUser = await this.usersRepository.findOneByOrFail({ id: note.userId });
 			this.moderationLogService.log(deleter, 'deleteNote', {
 				noteId: note.id,
 				noteUserId: note.userId,
-				noteUserUsername: user.username,
-				noteUserHost: user.host,
+				noteUserUsername: noteUser.username,
+				noteUserHost: noteUser.host,
 				note: note,
 			});
 		}
+
+		// チャート / 連合統計 / AP 配信をジョブキューに委譲
+		this.queueService.noteDelete({
+			noteId: note.id,
+			quiet,
+			userSnapshot: { id: user.id, uri: user.uri, host: user.host, isBot: user.isBot },
+			noteSnapshot: {
+				id: note.id,
+				userId: note.userId,
+				userHost: note.userHost,
+				visibility: note.visibility,
+				localOnly: note.localOnly,
+				channelId: note.channelId,
+				replyId: note.replyId,
+				renoteId: note.renoteId,
+				fileIds: note.fileIds,
+			},
+			apContent,
+			apRecipientIds,
+			isRemote: this.userEntityService.isRemoteUser(user),
+		});
 	}
 
 	@bindThis
 	private async getMentionedRemoteUsers(note: MiNote) {
 		const where = [] as any[];
 
-		// mention / reply / dm
 		const uris = (JSON.parse(note.mentionedRemoteUsers) as IMentionedRemoteUsers).map(x => x.uri);
 		if (uris.length > 0) {
-			where.push(
-				{ uri: In(uris) },
-			);
+			where.push({ uri: In(uris) });
 		}
 
-		// renote / quote
 		if (note.renoteUserId) {
-			where.push({
-				id: note.renoteUserId,
-			});
+			where.push({ id: note.renoteUserId });
 		}
 
 		if (where.length === 0) return [];
 
-		return await this.usersRepository.find({
-			where,
-		}) as MiRemoteUser[];
+		return await this.usersRepository.find({ where }) as MiRemoteUser[];
 	}
 
 	@bindThis
@@ -163,17 +148,6 @@ export class NoteDeleteService {
 			}))
 			.andWhere({ userHost: Not(IsNull()) });
 		const notes = await query.getMany() as (MiNote & { user: MiRemoteUser })[];
-		const remoteUsers = notes.map(({ user }) => user);
-		return remoteUsers;
-	}
-
-	@bindThis
-	private async deliverToConcerned(user: { id: MiLocalUser['id']; host: null; }, note: MiNote, content: any) {
-		this.apDeliverManagerService.deliverToFollowers(user, content);
-		this.relayService.deliverToRelays(user, content);
-		this.apDeliverManagerService.deliverToUsers(user, content, [
-			...await this.getMentionedRemoteUsers(note),
-			...await this.getRenotedOrRepliedRemoteUsers(note),
-		]);
+		return notes.map(({ user }) => user);
 	}
 }

--- a/packages/backend/src/core/NoteNotificationManagerService.ts
+++ b/packages/backend/src/core/NoteNotificationManagerService.ts
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable } from '@nestjs/common';
+import { MiNote } from '@/models/Note.js';
+import type { MiUser, MiLocalUser } from '@/models/User.js';
+import { NotificationService } from '@/core/NotificationService.js';
+import { bindThis } from '@/decorators.js';
+
+type NotificationType = 'reply' | 'renote' | 'quote' | 'mention';
+
+class NoteNotificationManager {
+	private queue: Map<MiLocalUser['id'], { target: MiLocalUser['id']; reason: NotificationType }> = new Map();
+
+	constructor(
+		private notificationService: NotificationService,
+		private notifier: { id: MiUser['id'] },
+		private note: MiNote,
+	) {}
+
+	@bindThis
+	public push(notifiee: MiLocalUser['id'], reason: NotificationType) {
+		if (this.notifier.id === notifiee) return;
+
+		const exist = this.queue.get(notifiee);
+		if (exist) {
+			if (reason !== 'mention') {
+				exist.reason = reason;
+			}
+		} else {
+			this.queue.set(notifiee, { reason, target: notifiee });
+		}
+	}
+
+	@bindThis
+	public async notify() {
+		if (this.queue.size === 0) return;
+
+		let visibleUserIds: Set<MiUser['id']> | null;
+
+		switch (this.note.visibility) {
+			case 'public':
+			case 'home':
+				visibleUserIds = null;
+				break;
+			case 'specified':
+				visibleUserIds = new Set(this.note.visibleUserIds);
+				break;
+			case 'followers':
+				// フォロワー限定ノートにフォロワーではない人がメンションされた場合は通知される（フィルタしない）
+				visibleUserIds = null;
+				break;
+			default:
+				visibleUserIds = new Set();
+				break;
+		}
+
+		for (const x of this.queue.values()) {
+			const isVisibleToTarget = visibleUserIds === null || visibleUserIds.has(x.target);
+			if (!isVisibleToTarget) continue;
+
+			if (x.reason === 'renote') {
+				this.notificationService.createNotification(x.target, 'renote', {
+					noteId: this.note.id,
+					targetNoteId: this.note.renoteId!,
+				}, this.notifier.id);
+			} else {
+				this.notificationService.createNotification(x.target, x.reason, {
+					noteId: this.note.id,
+				}, this.notifier.id);
+			}
+		}
+	}
+}
+
+@Injectable()
+export class NoteNotificationManagerService {
+	constructor(
+		private notificationService: NotificationService,
+	) {}
+
+	@bindThis
+	public create(notifier: { id: MiUser['id'] }, note: MiNote): NoteNotificationManager {
+		return new NoteNotificationManager(this.notificationService, notifier, note);
+	}
+}

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -47,12 +47,15 @@ import { systemWebhookDeliverJob, userWebhookDeliverJob } from '@/queue/jobs/def
 import { QueueRuntimeService } from '@/queue/QueueRuntimeService.js';
 import { endedPollNotificationJob } from '@/queue/jobs/definitions/misc.js';
 import { queueDefinitionFromType } from '@/queue/jobs/queueDefinitions.js';
+import { notePostJob, updateUserNotesCountJob } from '@/queue/jobs/definitions/note.js';
+import { noteDeleteJob } from '@/queue/jobs/definitions/noteDelete.js';
 import { type UserWebhookPayload } from './UserWebhookService.js';
 import type * as Bull from 'bullmq';
 import type httpSignature from '@peertube/http-signature';
 import type {
 	DeliverJobData,
 	SystemWebhookDeliverJobData,
+	NoteDeleteJobData,
 	ThinUser,
 	UserWebhookDeliverJobData,
 } from '../queue/types.js';
@@ -425,6 +428,25 @@ export class QueueService {
 
 	public async endedPollNotification(noteId: string, delay: number) {
 		return this.jobRuntime.enqueue(endedPollNotificationJob, { noteId }, { delay });
+	}
+
+	@bindThis
+	public notePost(noteId: string, silent: boolean) {
+		return this.jobRuntime.enqueue(notePostJob, { noteId, silent }, { jobId: `notePost-${noteId}` });
+	}
+
+	@bindThis
+	public noteDelete(data: NoteDeleteJobData) {
+		return this.jobRuntime.enqueue(noteDeleteJob, data, { jobId: `noteDelete-${data.noteId}` });
+	}
+
+	@bindThis
+	public updateUserNotesCount(userId: string) {
+		// 5 分以内の同一 userId 再 enqueue は BullMQ が既存 delayed ジョブを温存するため 1 回しか発火しない
+		return this.jobRuntime.enqueue(updateUserNotesCountJob, { userId }, {
+			jobId: `notesCount-${userId}`,
+			delay: 5 * 60 * 1000,
+		});
 	}
 
 	@bindThis

--- a/packages/backend/src/queue/QueueProcessorModule.ts
+++ b/packages/backend/src/queue/QueueProcessorModule.ts
@@ -12,6 +12,9 @@ import { DeliverProcessorService } from './processors/DeliverProcessorService.js
 import { EndedPollNotificationProcessorService } from './processors/EndedPollNotificationProcessorService.js';
 import { PostScheduledNoteProcessorService } from './processors/PostScheduledNoteProcessorService.js';
 import { InboxProcessorService } from './processors/InboxProcessorService.js';
+import { NoteProcessorService } from './processors/NoteProcessorService.js';
+import { NoteDeleteProcessorService } from './processors/NoteDeleteProcessorService.js';
+import { UpdateUserNotesCountProcessorService } from './processors/UpdateUserNotesCountProcessorService.js';
 import { UserWebhookDeliverProcessorService } from './processors/UserWebhookDeliverProcessorService.js';
 import { SystemWebhookDeliverProcessorService } from './processors/SystemWebhookDeliverProcessorService.js';
 import { CheckExpiredMutingsProcessorService } from './processors/CheckExpiredMutingsProcessorService.js';
@@ -83,6 +86,9 @@ import { RelationshipProcessorService } from './processors/RelationshipProcessor
 		PostScheduledNoteProcessorService,
 		DeliverProcessorService,
 		InboxProcessorService,
+		NoteProcessorService,
+		NoteDeleteProcessorService,
+		UpdateUserNotesCountProcessorService,
 		AggregateRetentionProcessorService,
 		CheckExpiredMutingsProcessorService,
 		CheckModeratorsActivityProcessorService,

--- a/packages/backend/src/queue/QueueProcessorService.ts
+++ b/packages/backend/src/queue/QueueProcessorService.ts
@@ -42,6 +42,13 @@ import {
 	postScheduledNoteJob,
 } from '@/queue/jobs/definitions/misc.js';
 import {
+	notePostJob,
+	updateUserNotesCountJob,
+} from '@/queue/jobs/definitions/note.js';
+import {
+	noteDeleteJob,
+} from '@/queue/jobs/definitions/noteDelete.js';
+import {
 	cleanRemoteFilesJob,
 	deleteFileJob,
 } from '@/queue/jobs/definitions/objectStorage.js';
@@ -96,6 +103,9 @@ import { ImportFollowingProcessorService } from './processors/ImportFollowingPro
 import { ImportMutingProcessorService } from './processors/ImportMutingProcessorService.js';
 import { ImportUserListsProcessorService } from './processors/ImportUserListsProcessorService.js';
 import { InboxProcessorService } from './processors/InboxProcessorService.js';
+import { NoteProcessorService } from './processors/NoteProcessorService.js';
+import { NoteDeleteProcessorService } from './processors/NoteDeleteProcessorService.js';
+import { UpdateUserNotesCountProcessorService } from './processors/UpdateUserNotesCountProcessorService.js';
 import { PostScheduledNoteProcessorService } from './processors/PostScheduledNoteProcessorService.js';
 import { RelationshipProcessorService } from './processors/RelationshipProcessorService.js';
 import { ResyncChartsProcessorService } from './processors/ResyncChartsProcessorService.js';
@@ -133,6 +143,9 @@ export class QueueProcessorService implements OnApplicationShutdown {
 		private systemWebhookDeliverProcessorService: SystemWebhookDeliverProcessorService,
 		private endedPollNotificationProcessorService: EndedPollNotificationProcessorService,
 		private postScheduledNoteProcessorService: PostScheduledNoteProcessorService,
+		private noteProcessorService: NoteProcessorService,
+		private noteDeleteProcessorService: NoteDeleteProcessorService,
+		private updateUserNotesCountProcessorService: UpdateUserNotesCountProcessorService,
 		private deliverProcessorService: DeliverProcessorService,
 		private inboxProcessorService: InboxProcessorService,
 		private deleteDriveFilesProcessorService: DeleteDriveFilesProcessorService,
@@ -355,6 +368,23 @@ export class QueueProcessorService implements OnApplicationShutdown {
 			const hooks = makeHooks(logger, 'ObjectStorage', 'debug');
 			jobRuntime.handle(deleteFileJob, wrapProcessor((job) => this.deleteFileProcessorService.process(job)), { hooks });
 			jobRuntime.handle(cleanRemoteFilesJob, wrapProcessor((job) => this.cleanRemoteFilesProcessorService.process(job)), { hooks });
+		}
+		//#endregion
+
+		//#region note post
+		{
+			const logger = this.logger.createSubLogger('note-post');
+			const hooks = makeHooks(logger, 'NotePost', 'debug');
+			jobRuntime.handle(notePostJob, wrapProcessor((job) => this.noteProcessorService.process(job)), { hooks });
+			jobRuntime.handle(updateUserNotesCountJob, wrapProcessor((job) => this.updateUserNotesCountProcessorService.process(job)), { hooks });
+		}
+		//#endregion
+
+		//#region note delete
+		{
+			const logger = this.logger.createSubLogger('note-delete');
+			const hooks = makeHooks(logger, 'NoteDelete', 'debug');
+			jobRuntime.handle(noteDeleteJob, wrapProcessor((job) => this.noteDeleteProcessorService.process(job)), { hooks });
 		}
 		//#endregion
 

--- a/packages/backend/src/queue/const.ts
+++ b/packages/backend/src/queue/const.ts
@@ -14,6 +14,8 @@ export const QUEUE = {
 	OBJECT_STORAGE: 'objectStorage',
 	USER_WEBHOOK_DELIVER: 'userWebhookDeliver',
 	SYSTEM_WEBHOOK_DELIVER: 'systemWebhookDeliver',
+	NOTE_POST: 'notePost',
+	NOTE_DELETE: 'noteDelete',
 } as const;
 
 export const QUEUE_TYPES = Object.values(QUEUE);

--- a/packages/backend/src/queue/jobs/definitions/note.ts
+++ b/packages/backend/src/queue/jobs/definitions/note.ts
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { defineQueueForBullMQ } from '@mokurokujs/bullmq-adapter';
+import { defineJob } from '@mokurokujs/core';
+import { loadConfig } from '@/config.js';
+import { QUEUE } from '@/queue/const.js';
+import { baseQueueOptions, baseWorkerOptions } from '@/queue/helper.js';
+import type { NotePostJobData, UpdateUserNotesCountJobData } from '@/queue/types.js';
+
+const config = loadConfig();
+
+/** 共通の削除ポリシー */
+const defaultRemovePolicy = {
+	removeOnComplete: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 30,
+	},
+	removeOnFail: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 100,
+	},
+} as const;
+
+export const notePostQueue = defineQueueForBullMQ(QUEUE.NOTE_POST, {
+	queueOptions: {
+		...baseQueueOptions(config, QUEUE.NOTE_POST),
+	},
+	workerOptions: {
+		autorun: false,
+		concurrency: 4,
+		...baseWorkerOptions(config, QUEUE.NOTE_POST),
+	},
+}).build();
+
+export const notePostJob = defineJob<NotePostJobData>('notePost', {
+	queue: notePostQueue,
+	attempts: 2,
+	...defaultRemovePolicy,
+});
+
+export const updateUserNotesCountJob = defineJob<UpdateUserNotesCountJobData>('updateUserNotesCount', {
+	queue: notePostQueue,
+	attempts: 2,
+	// 完了即削除: jobId dedup が completed 状態でもブロックしないよう removeOnComplete: true にする
+	removeOnComplete: true,
+	removeOnFail: defaultRemovePolicy.removeOnFail,
+});

--- a/packages/backend/src/queue/jobs/definitions/noteDelete.ts
+++ b/packages/backend/src/queue/jobs/definitions/noteDelete.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { defineQueueForBullMQ } from '@mokurokujs/bullmq-adapter';
+import { defineJob } from '@mokurokujs/core';
+import { loadConfig } from '@/config.js';
+import { QUEUE } from '@/queue/const.js';
+import { baseQueueOptions, baseWorkerOptions } from '@/queue/helper.js';
+import type { NoteDeleteJobData } from '@/queue/types.js';
+
+const config = loadConfig();
+
+/** 共通の削除ポリシー */
+const defaultRemovePolicy = {
+	removeOnComplete: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 30,
+	},
+	removeOnFail: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 100,
+	},
+} as const;
+
+export const noteDeleteQueue = defineQueueForBullMQ(QUEUE.NOTE_DELETE, {
+	queueOptions: {
+		...baseQueueOptions(config, QUEUE.NOTE_DELETE),
+	},
+	workerOptions: {
+		autorun: false,
+		concurrency: 4,
+		...baseWorkerOptions(config, QUEUE.NOTE_DELETE),
+	},
+}).build();
+
+export const noteDeleteJob = defineJob<NoteDeleteJobData>('noteDelete', {
+	queue: noteDeleteQueue,
+	attempts: 2,
+	...defaultRemovePolicy,
+});

--- a/packages/backend/src/queue/jobs/queueDefinitions.ts
+++ b/packages/backend/src/queue/jobs/queueDefinitions.ts
@@ -11,7 +11,9 @@ import { endedPollNotificationQueue, postScheduledNoteQueue } from '@/queue/jobs
 import { dbQueue } from '@/queue/jobs/definitions/db.js';
 import { relationshipQueue } from '@/queue/jobs/definitions/relationship.js';
 import { objectStorageQueue } from '@/queue/jobs/definitions/objectStorage.js';
-import { userWebhookDeliverQueue, systemWebhookDeliverQueue } from '@/queue/jobs/definitions/webhook.js';
+import { systemWebhookDeliverQueue, userWebhookDeliverQueue } from '@/queue/jobs/definitions/webhook.js';
+import { notePostQueue } from '@/queue/jobs/definitions/note.js';
+import { noteDeleteQueue } from '@/queue/jobs/definitions/noteDelete.js';
 import type { QueueDefinition } from '@mokurokujs/core';
 
 const definitionsByType: Record<QueueType, QueueDefinition> = {
@@ -25,9 +27,10 @@ const definitionsByType: Record<QueueType, QueueDefinition> = {
 	[QUEUE.OBJECT_STORAGE]: objectStorageQueue,
 	[QUEUE.USER_WEBHOOK_DELIVER]: userWebhookDeliverQueue,
 	[QUEUE.SYSTEM_WEBHOOK_DELIVER]: systemWebhookDeliverQueue,
+	[QUEUE.NOTE_POST]: notePostQueue,
+	[QUEUE.NOTE_DELETE]: noteDeleteQueue,
 };
 
 export function queueDefinitionFromType(queueType: QueueType): QueueDefinition {
 	return definitionsByType[queueType];
 }
-

--- a/packages/backend/src/queue/processors/NoteDeleteProcessorService.ts
+++ b/packages/backend/src/queue/processors/NoteDeleteProcessorService.ts
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import { In } from 'typeorm';
+import * as Bull from 'bullmq';
+import type { InstancesRepository, UsersRepository } from '@/models/_.js';
+import type { MiLocalUser, MiRemoteUser } from '@/models/User.js';
+import { DI } from '@/di-symbols.js';
+import type { MiMeta } from '@/models/Meta.js';
+import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
+import { RelayService } from '@/core/RelayService.js';
+import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
+import { UserEntityService } from '@/core/entities/UserEntityService.js';
+import NotesChart from '@/core/chart/charts/notes.js';
+import PerUserNotesChart from '@/core/chart/charts/per-user-notes.js';
+import InstanceChart from '@/core/chart/charts/instance.js';
+import { bindThis } from '@/decorators.js';
+import { QueueService } from '@/core/QueueService.js';
+import type { NoteDeleteJobData } from '@/queue/types.js';
+import type Logger from '@/logger.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+@Injectable()
+export class NoteDeleteProcessorService {
+	private logger: Logger;
+
+	constructor(
+		@Inject(DI.meta)
+		private meta: MiMeta,
+
+		@Inject(DI.usersRepository)
+		private usersRepository: UsersRepository,
+
+		@Inject(DI.instancesRepository)
+		private instancesRepository: InstancesRepository,
+
+		private userEntityService: UserEntityService,
+		private apDeliverManagerService: ApDeliverManagerService,
+		private relayService: RelayService,
+		private federatedInstanceService: FederatedInstanceService,
+		private queueService: QueueService,
+		private notesChart: NotesChart,
+		private perUserNotesChart: PerUserNotesChart,
+		private instanceChart: InstanceChart,
+		private queueLoggerService: QueueLoggerService,
+	) {
+		this.logger = this.queueLoggerService.logger.createSubLogger('note-delete');
+	}
+
+	@bindThis
+	public async process(job: Bull.Job<NoteDeleteJobData>): Promise<void> {
+		const { noteSnapshot, userSnapshot, apContent, apRecipientIds, quiet, isRemote } = job.data;
+
+		if (!quiet) {
+			this.notesChart.update(noteSnapshot as any, false);
+			if (this.meta.enableChartsForRemoteUser || !isRemote) {
+				this.perUserNotesChart.update(userSnapshot, noteSnapshot as any, false);
+			}
+
+			if (this.meta.enableStatsForFederatedInstances && isRemote && userSnapshot.host) {
+				this.federatedInstanceService.fetchOrRegister(userSnapshot.host).then(async i => {
+					this.instancesRepository.decrement({ id: i.id }, 'notesCount', 1);
+					if (this.meta.enableChartsForFederatedInstances) {
+						this.instanceChart.updateNote(i.host, noteSnapshot as any, false);
+					}
+				});
+			}
+
+			if (apContent !== null && userSnapshot.uri === null) {
+				const localUser = { id: userSnapshot.id, host: null as null };
+				const dm = this.apDeliverManagerService.createDeliverManager(localUser as unknown as MiLocalUser, apContent);
+
+				if (apRecipientIds.length > 0) {
+					const recipients = await this.usersRepository.findBy({ id: In(apRecipientIds) }) as MiRemoteUser[];
+					for (const recipient of recipients) {
+						dm.addDirectRecipe(recipient);
+					}
+				}
+
+				if (['public', 'home', 'followers'].includes(noteSnapshot.visibility)) {
+					dm.addFollowersRecipe();
+				}
+				await this.relayService.deliverToRelays(localUser as unknown as MiLocalUser, apContent);
+				await dm.execute();
+			}
+		}
+
+		this.queueService.updateUserNotesCount(userSnapshot.id);
+	}
+}

--- a/packages/backend/src/queue/processors/NoteProcessorService.ts
+++ b/packages/backend/src/queue/processors/NoteProcessorService.ts
@@ -1,0 +1,579 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import * as Bull from 'bullmq';
+import { In, IsNull, LessThan } from 'typeorm';
+import * as Redis from 'ioredis';
+import { NoteNotificationManagerService } from '@/core/NoteNotificationManagerService.js';
+import type { Config } from '@/config.js';
+import { DI } from '@/di-symbols.js';
+import type {
+	ChannelFollowingsRepository,
+	ChannelsRepository,
+	FollowingsRepository,
+	InstancesRepository,
+	MutingsRepository,
+	NoteThreadMutingsRepository,
+	NotesRepository,
+	PollsRepository,
+	UserListMembershipsRepository,
+	UsersRepository,
+} from '@/models/_.js';
+import { MiNote } from '@/models/Note.js';
+import type { MiUser, MiLocalUser, MiRemoteUser } from '@/models/User.js';
+import type { MiChannel } from '@/models/Channel.js';
+import type { MiMeta } from '@/models/Meta.js';
+import { FanoutTimelineService } from '@/core/FanoutTimelineService.js';
+import { UserEntityService } from '@/core/entities/UserEntityService.js';
+import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
+import { NotificationService } from '@/core/NotificationService.js';
+import { UserWebhookService } from '@/core/UserWebhookService.js';
+import { HashtagService } from '@/core/HashtagService.js';
+import { AntennaService } from '@/core/AntennaService.js';
+import { QueueService } from '@/core/QueueService.js';
+import { SearchService } from '@/core/SearchService.js';
+import { RelayService } from '@/core/RelayService.js';
+import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
+import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
+import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
+import NotesChart from '@/core/chart/charts/notes.js';
+import PerUserNotesChart from '@/core/chart/charts/per-user-notes.js';
+import ActiveUsersChart from '@/core/chart/charts/active-users.js';
+import InstanceChart from '@/core/chart/charts/instance.js';
+import { FeaturedService } from '@/core/FeaturedService.js';
+import { CacheService } from '@/core/CacheService.js';
+import { bindThis } from '@/decorators.js';
+import { isRenote, isQuote } from '@/misc/is-renote.js';
+import { isReply } from '@/misc/is-reply.js';
+import { IdService } from '@/core/IdService.js';
+import type { NotePostJobData } from '@/queue/types.js';
+import type Logger from '@/logger.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+@Injectable()
+export class NoteProcessorService {
+	private logger: Logger;
+
+	constructor(
+		@Inject(DI.config)
+		private config: Config,
+
+		@Inject(DI.meta)
+		private meta: MiMeta,
+
+		@Inject(DI.redisForTimelines)
+		private redisForTimelines: Redis.Redis,
+
+		@Inject(DI.usersRepository)
+		private usersRepository: UsersRepository,
+
+		@Inject(DI.notesRepository)
+		private notesRepository: NotesRepository,
+
+		@Inject(DI.mutingsRepository)
+		private mutingsRepository: MutingsRepository,
+
+		@Inject(DI.noteThreadMutingsRepository)
+		private noteThreadMutingsRepository: NoteThreadMutingsRepository,
+
+		@Inject(DI.followingsRepository)
+		private followingsRepository: FollowingsRepository,
+
+		@Inject(DI.userListMembershipsRepository)
+		private userListMembershipsRepository: UserListMembershipsRepository,
+
+		@Inject(DI.channelFollowingsRepository)
+		private channelFollowingsRepository: ChannelFollowingsRepository,
+
+		@Inject(DI.channelsRepository)
+		private channelsRepository: ChannelsRepository,
+
+		@Inject(DI.pollsRepository)
+		private pollsRepository: PollsRepository,
+
+		@Inject(DI.instancesRepository)
+		private instancesRepository: InstancesRepository,
+
+		private idService: IdService,
+		private userEntityService: UserEntityService,
+		private noteEntityService: NoteEntityService,
+		private fanoutTimelineService: FanoutTimelineService,
+		private notificationService: NotificationService,
+		private noteNotificationManagerService: NoteNotificationManagerService,
+		private webhookService: UserWebhookService,
+		private hashtagService: HashtagService,
+		private antennaService: AntennaService,
+		private queueService: QueueService,
+		private searchService: SearchService,
+		private relayService: RelayService,
+		private federatedInstanceService: FederatedInstanceService,
+		private apDeliverManagerService: ApDeliverManagerService,
+		private apRendererService: ApRendererService,
+		private featuredService: FeaturedService,
+		private notesChart: NotesChart,
+		private perUserNotesChart: PerUserNotesChart,
+		private activeUsersChart: ActiveUsersChart,
+		private instanceChart: InstanceChart,
+		private cacheService: CacheService,
+		private queueLoggerService: QueueLoggerService,
+	) {
+		this.logger = this.queueLoggerService.logger.createSubLogger('note-post');
+	}
+
+	@bindThis
+	public async process(job: Bull.Job<NotePostJobData>): Promise<void> {
+		const { noteId, silent } = job.data;
+
+		const note = await this.notesRepository.findOneBy({ id: noteId });
+		if (note == null) {
+			this.logger.debug(`note ${noteId} already deleted; skipping`);
+			return;
+		}
+		const user = await this.usersRepository.findOneBy({ id: note.userId });
+		if (user == null) {
+			this.logger.debug(`user ${note.userId} already deleted; skipping`);
+			return;
+		}
+
+		const results = await Promise.allSettled([
+			this.runRealtime(note),
+			this.runNotifications(note, user, silent),
+			this.runBackgroundWork(note, user, silent),
+		]);
+
+		for (const result of results) {
+			if (result.status === 'rejected') {
+				this.logger.warn('notePost subtask failed', { error: result.reason instanceof Error ? { name: result.reason.name, message: result.reason.message, stack: result.reason.stack } : String(result.reason) });
+			}
+		}
+	}
+
+	@bindThis
+	private async runRealtime(note: MiNote): Promise<void> {
+		await this.pushToTl(note);
+	}
+
+	@bindThis
+	private async runNotifications(note: MiNote, user: MiUser, silent: boolean): Promise<void> {
+		if (silent) return;
+
+		const noteObj = await this.noteEntityService.pack(note, null, { skipHide: true, withReactionAndUserPairCache: true });
+
+		if (this.userEntityService.isLocalUser(user)) {
+			this.activeUsersChart.write(user as MiLocalUser);
+		}
+
+		this.webhookService.enqueueUserWebhook(user.id, 'note', { note: noteObj });
+
+		const nm = this.noteNotificationManagerService.create(user, note);
+
+		if (note.replyId) {
+			if (note.replyUserHost === null) {
+				const threadId = note.threadId ?? note.replyId;
+				const isThreadMuted = await this.noteThreadMutingsRepository.exists({
+					where: {
+						userId: note.replyUserId!,
+						threadId,
+					},
+				});
+
+				if (!isThreadMuted) {
+					nm.push(note.replyUserId as MiLocalUser['id'], 'reply');
+					this.webhookService.enqueueUserWebhook(note.replyUserId!, 'reply', { note: noteObj });
+				}
+			}
+		}
+
+		if (isRenote(note)) {
+			const type = isQuote(note) ? 'quote' : 'renote';
+
+			if (note.renoteUserHost === null) {
+				nm.push(note.renoteUserId as MiLocalUser['id'], type);
+			}
+
+			if ((user.id !== note.renoteUserId) && note.renoteUserHost === null) {
+				this.webhookService.enqueueUserWebhook(note.renoteUserId!, 'renote', { note: noteObj });
+			}
+		}
+
+		const mentionedUsers = await this.fetchMentionedUsers(note);
+		await this.createMentionedEvents(mentionedUsers, note, nm);
+
+		nm.notify();
+
+		if (!note.replyId) {
+			this.followingsRepository.findBy({
+				followeeId: user.id,
+				notify: 'normal',
+			}).then(async followings => {
+				if (note.visibility !== 'specified') {
+					const isPureRenote = isRenote(note) && !isQuote(note);
+					for (const following of followings) {
+						let isRenoteMuted = false;
+						if (isPureRenote) {
+							const userIdsWhoMeMutingRenotes = await this.cacheService.renoteMutingsCache.fetch(following.followerId);
+							isRenoteMuted = userIdsWhoMeMutingRenotes.has(user.id);
+						}
+						if (!isRenoteMuted) {
+							this.notificationService.createNotification(following.followerId, 'note', {
+								noteId: note.id,
+							}, user.id);
+						}
+					}
+				}
+			});
+		}
+	}
+
+	@bindThis
+	private async runBackgroundWork(note: MiNote, user: MiUser, silent: boolean): Promise<void> {
+		if (note.visibility === 'public' || note.visibility === 'home') {
+			this.hashtagService.updateHashtags(user, note.tags ?? []);
+		}
+
+		this.queueService.updateUserNotesCount(user.id);
+
+		const channel = note.channelId
+			? await this.channelsRepository.findOneBy({ id: note.channelId })
+			: null;
+
+		this.antennaService.addNoteToAntennas({
+			...note,
+			channel: channel ?? null,
+		} as MiNote & { channel: MiChannel | null }, user);
+
+		if (note.replyId) {
+			this.notesRepository.increment({ id: note.replyId }, 'repliesCount', 1);
+		}
+
+		if (note.hasPoll) {
+			const poll = await this.pollsRepository.findOneBy({ noteId: note.id });
+			if (poll?.expiresAt) {
+				const delay = poll.expiresAt.getTime() - Date.now();
+				this.queueService.endedPollNotification(note.id, delay);
+			}
+		}
+
+		if (note.channelId) {
+			this.channelsRepository.increment({ id: note.channelId }, 'notesCount', 1);
+			this.channelsRepository.update(note.channelId, { lastNotedAt: new Date() });
+
+			this.notesRepository.countBy({
+				userId: user.id,
+				channelId: note.channelId,
+			}).then(count => {
+				if (count === 1) {
+					this.channelsRepository.increment({ id: note.channelId! }, 'usersCount', 1);
+				}
+			});
+		}
+
+		this.notesChart.update(note, true);
+		if (note.visibility !== 'specified' && (this.meta.enableChartsForRemoteUser || (user.host == null))) {
+			this.perUserNotesChart.update(user, note, true);
+		}
+
+		if (this.meta.enableStatsForFederatedInstances && this.userEntityService.isRemoteUser(user)) {
+			this.federatedInstanceService.fetchOrRegister(user.host).then(async i => {
+				await this.instancesRepository.increment({ id: i.id }, 'notesCount', 1);
+				if (this.meta.enableChartsForFederatedInstances) {
+					this.instanceChart.updateNote(i.host, note, true);
+				}
+			});
+		}
+
+		if (isRenote(note) && note.renoteUserId !== user.id && !user.isBot) {
+			const renoteTarget = await this.notesRepository.findOneByOrFail({ id: note.renoteId });
+			this.incRenoteCount(renoteTarget);
+		}
+
+		this.index(note);
+
+		if (!silent) {
+			await this.deliverActivity(note, user);
+		}
+	}
+
+	@bindThis
+	private async fetchMentionedUsers(note: MiNote): Promise<MiUser[]> {
+		if (!note.mentions || note.mentions.length === 0) return [];
+		return await this.usersRepository.findBy({ id: In(note.mentions) });
+	}
+
+	@bindThis
+	private async pushToTl(note: MiNote) {
+		if (!this.meta.enableFanoutTimeline) return;
+
+		const r = this.redisForTimelines.pipeline();
+
+		if (note.channelId) {
+			this.fanoutTimelineService.push(`channelTimeline:${note.channelId}`, note.id, this.config.perChannelMaxNoteCacheCount, r);
+
+			this.fanoutTimelineService.push(`userTimelineWithChannel:${note.userId}`, note.id, note.userHost == null ? this.meta.perLocalUserUserTimelineCacheMax : this.meta.perRemoteUserUserTimelineCacheMax, r);
+
+			const channelFollowings = await this.channelFollowingsRepository.find({
+				where: {
+					followeeId: note.channelId,
+				},
+				select: ['followerId'],
+			});
+
+			for (const channelFollowing of channelFollowings) {
+				this.fanoutTimelineService.push(`homeTimeline:${channelFollowing.followerId}`, note.id, this.meta.perUserHomeTimelineCacheMax, r);
+				if (note.fileIds.length > 0) {
+					this.fanoutTimelineService.push(`homeTimelineWithFiles:${channelFollowing.followerId}`, note.id, this.meta.perUserHomeTimelineCacheMax / 2, r);
+				}
+			}
+		} else {
+			const [followings, fetchedUserListMemberships] = await Promise.all([
+				this.followingsRepository.find({
+					where: {
+						followeeId: note.userId,
+						followerHost: IsNull(),
+						isFollowerHibernated: false,
+					},
+					select: ['followerId', 'withReplies'],
+				}),
+				this.userListMembershipsRepository.find({
+					where: {
+						userId: note.userId,
+					},
+					select: ['userListId', 'userListUserId', 'withReplies'],
+				}),
+			]);
+			let userListMemberships = fetchedUserListMemberships;
+
+			if (note.visibility === 'followers') {
+				userListMemberships = userListMemberships.filter(x => x.userListUserId === note.userId || followings.some(f => f.followerId === x.userListUserId));
+			}
+
+			for (const following of followings) {
+				if (note.visibility === 'specified' && !note.visibleUserIds.some(v => v === following.followerId)) continue;
+
+				if (isReply(note, following.followerId)) {
+					if (!following.withReplies) continue;
+				}
+
+				this.fanoutTimelineService.push(`homeTimeline:${following.followerId}`, note.id, this.meta.perUserHomeTimelineCacheMax, r);
+				if (note.fileIds.length > 0) {
+					this.fanoutTimelineService.push(`homeTimelineWithFiles:${following.followerId}`, note.id, this.meta.perUserHomeTimelineCacheMax / 2, r);
+				}
+			}
+
+			for (const userListMembership of userListMemberships) {
+				if (
+					note.visibility === 'specified' &&
+					note.userId !== userListMembership.userListUserId &&
+					!note.visibleUserIds.some(v => v === userListMembership.userListUserId)
+				) continue;
+
+				if (isReply(note, userListMembership.userListUserId)) {
+					if (!userListMembership.withReplies) continue;
+				}
+
+				this.fanoutTimelineService.push(`userListTimeline:${userListMembership.userListId}`, note.id, this.meta.perUserListTimelineCacheMax, r);
+				if (note.fileIds.length > 0) {
+					this.fanoutTimelineService.push(`userListTimelineWithFiles:${userListMembership.userListId}`, note.id, this.meta.perUserListTimelineCacheMax / 2, r);
+				}
+			}
+
+			if (note.userHost == null) {
+				if (note.visibility !== 'specified' || !note.visibleUserIds.some(v => v === note.userId)) {
+					this.fanoutTimelineService.push(`homeTimeline:${note.userId}`, note.id, this.meta.perUserHomeTimelineCacheMax, r);
+					if (note.fileIds.length > 0) {
+						this.fanoutTimelineService.push(`homeTimelineWithFiles:${note.userId}`, note.id, this.meta.perUserHomeTimelineCacheMax / 2, r);
+					}
+				}
+			}
+
+			if (isReply(note)) {
+				this.fanoutTimelineService.push(`userTimelineWithReplies:${note.userId}`, note.id, note.userHost == null ? this.meta.perLocalUserUserTimelineCacheMax : this.meta.perRemoteUserUserTimelineCacheMax, r);
+
+				if (note.visibility === 'public' && note.userHost == null) {
+					this.fanoutTimelineService.push('localTimelineWithReplies', note.id, 300, r);
+					if (note.replyUserHost == null) {
+						this.fanoutTimelineService.push(`localTimelineWithReplyTo:${note.replyUserId}`, note.id, 300 / 10, r);
+					}
+				}
+			} else {
+				this.fanoutTimelineService.push(`userTimeline:${note.userId}`, note.id, note.userHost == null ? this.meta.perLocalUserUserTimelineCacheMax : this.meta.perRemoteUserUserTimelineCacheMax, r);
+				if (note.fileIds.length > 0) {
+					this.fanoutTimelineService.push(`userTimelineWithFiles:${note.userId}`, note.id, note.userHost == null ? this.meta.perLocalUserUserTimelineCacheMax / 2 : this.meta.perRemoteUserUserTimelineCacheMax / 2, r);
+				}
+
+				if (note.visibility === 'public' && note.userHost == null) {
+					this.fanoutTimelineService.push('localTimeline', note.id, 1000, r);
+					if (note.fileIds.length > 0) {
+						this.fanoutTimelineService.push('localTimelineWithFiles', note.id, 500, r);
+					}
+				}
+			}
+
+			if (Math.random() < 0.1) {
+				process.nextTick(() => {
+					this.checkHibernation(followings);
+				});
+			}
+		}
+
+		r.exec();
+	}
+
+	@bindThis
+	private async checkHibernation(followings: { followerId: string }[]) {
+		if (followings.length === 0) return;
+
+		const shuffle = (array: { followerId: string }[]) => {
+			for (let i = array.length - 1; i > 0; i--) {
+				const j = Math.floor(Math.random() * (i + 1));
+				[array[i], array[j]] = [array[j], array[i]];
+			}
+			return array;
+		};
+
+		const samples = shuffle(followings).slice(0, Math.min(followings.length, 1000));
+
+		const hibernatedUsers = await this.usersRepository.find({
+			where: {
+				id: In(samples.map(x => x.followerId)),
+				lastActiveDate: LessThan(new Date(Date.now() - (1000 * 60 * 60 * 24 * 50))),
+			},
+			select: ['id'],
+		});
+
+		if (hibernatedUsers.length > 0) {
+			this.usersRepository.update({
+				id: In(hibernatedUsers.map(x => x.id)),
+			}, {
+				isHibernated: true,
+			});
+
+			this.followingsRepository.update({
+				followerId: In(hibernatedUsers.map(x => x.id)),
+			}, {
+				isFollowerHibernated: true,
+			});
+		}
+	}
+
+	@bindThis
+	private async createMentionedEvents(mentionedUsers: MiUser[], note: MiNote, nm: ReturnType<NoteNotificationManagerService['create']>) {
+		const localMentionedUsers = mentionedUsers.filter(u => this.userEntityService.isLocalUser(u));
+		if (localMentionedUsers.length === 0) return;
+
+		const threadId = note.threadId ?? note.id;
+		const localMentionedUserIds = localMentionedUsers.map(u => u.id);
+
+		const muted = await this.noteThreadMutingsRepository.find({
+			where: {
+				threadId,
+				userId: In(localMentionedUserIds),
+			},
+			select: ['userId'],
+		});
+		const mutedUserIds = new Set(muted.map(x => x.userId));
+
+		for (const u of localMentionedUsers) {
+			if (mutedUserIds.has(u.id)) continue;
+
+			const detailPackedNote = await this.noteEntityService.pack(note, u, {
+				detail: true,
+			});
+
+			this.webhookService.enqueueUserWebhook(u.id, 'mention', { note: detailPackedNote });
+
+			nm.push(u.id, 'mention');
+		}
+	}
+
+	@bindThis
+	private incRenoteCount(renote: MiNote) {
+		this.notesRepository.createQueryBuilder().update()
+			.set({
+				renoteCount: () => '"renoteCount" + 1',
+			})
+			.where('id = :id', { id: renote.id })
+			.execute();
+
+		if (Math.random() < 0.3 && (Date.now() - this.idService.parse(renote.id).date.getTime()) < 1000 * 60 * 60 * 24 * 3) {
+			if (renote.channelId != null) {
+				if (renote.replyId == null) {
+					this.featuredService.updateInChannelNotesRanking(renote.channelId, renote.id, 5);
+				}
+			} else {
+				if (renote.visibility === 'public' && renote.userHost == null && renote.replyId == null) {
+					this.featuredService.updateGlobalNotesRanking(renote.id, 5);
+					this.featuredService.updatePerUserNotesRanking(renote.userId, renote.id, 5);
+				}
+			}
+		}
+	}
+
+	@bindThis
+	private index(note: MiNote) {
+		if (note.text == null && note.cw == null) return;
+		this.searchService.indexNote(note);
+	}
+
+	@bindThis
+	private async renderNoteOrRenoteActivity(note: MiNote) {
+		if (note.localOnly) return null;
+
+		if (isRenote(note) && !isQuote(note)) {
+			const renoteTarget = await this.notesRepository.findOneByOrFail({ id: note.renoteId });
+			const targetUri = renoteTarget.uri ? renoteTarget.uri : `${this.config.url}/notes/${renoteTarget.id}`;
+			const content = this.apRendererService.renderAnnounce(targetUri, note);
+			return this.apRendererService.addContext(content);
+		} else {
+			const content = this.apRendererService.renderCreate(await this.apRendererService.renderNote(note, false), note);
+			return this.apRendererService.addContext(content);
+		}
+	}
+
+	@bindThis
+	private async deliverActivity(note: MiNote, user: MiUser) {
+		if (note.localOnly) return;
+		if (!this.userEntityService.isLocalUser(user)) return;
+
+		try {
+			const noteActivity = await this.renderNoteOrRenoteActivity(note);
+			const dm = this.apDeliverManagerService.createDeliverManager(user as MiLocalUser, noteActivity);
+
+			const mentionedUsers = await this.fetchMentionedUsers(note);
+			for (const u of mentionedUsers.filter(u => this.userEntityService.isRemoteUser(u))) {
+				dm.addDirectRecipe(u as MiRemoteUser);
+			}
+
+			if (note.replyId && note.replyUserHost !== null) {
+				const u = await this.usersRepository.findOneBy({ id: note.replyUserId! });
+				if (u && this.userEntityService.isRemoteUser(u)) dm.addDirectRecipe(u);
+			}
+
+			if (note.renoteId && note.renoteUserHost !== null) {
+				const u = await this.usersRepository.findOneBy({ id: note.renoteUserId! });
+				if (u && this.userEntityService.isRemoteUser(u)) dm.addDirectRecipe(u);
+			}
+
+			if (['public', 'home', 'followers'].includes(note.visibility)) {
+				dm.addFollowersRecipe();
+			}
+
+			if (['public'].includes(note.visibility)) {
+				await this.relayService.deliverToRelays(user as MiLocalUser, noteActivity);
+			}
+
+			await dm.execute();
+		} catch (err) {
+			const errName = err instanceof Error ? err.name : 'Error';
+			const errMsg = err instanceof Error ? err.message : String(err);
+			this.logger.warn(`deliverActivity failed(${errName}: ${errMsg})`, {
+				noteId: note.id,
+				userId: user.id,
+				e: err instanceof Error ? { name: err.name, message: err.message, stack: err.stack } : String(err),
+			});
+		}
+	}
+}

--- a/packages/backend/src/queue/processors/UpdateUserNotesCountProcessorService.ts
+++ b/packages/backend/src/queue/processors/UpdateUserNotesCountProcessorService.ts
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import * as Bull from 'bullmq';
+import type { NotesRepository, UsersRepository } from '@/models/_.js';
+import { DI } from '@/di-symbols.js';
+import { bindThis } from '@/decorators.js';
+import type { UpdateUserNotesCountJobData } from '@/queue/types.js';
+import type Logger from '@/logger.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+@Injectable()
+export class UpdateUserNotesCountProcessorService {
+	private logger: Logger;
+
+	constructor(
+		@Inject(DI.usersRepository)
+		private usersRepository: UsersRepository,
+
+		@Inject(DI.notesRepository)
+		private notesRepository: NotesRepository,
+
+		private queueLoggerService: QueueLoggerService,
+	) {
+		this.logger = this.queueLoggerService.logger.createSubLogger('update-user-notes-count');
+	}
+
+	@bindThis
+	public async process(job: Bull.Job<UpdateUserNotesCountJobData>): Promise<void> {
+		const { userId } = job.data;
+
+		const count = await this.notesRepository.countBy({ userId });
+
+		await this.usersRepository.update(userId, {
+			notesCount: count,
+			updatedAt: new Date(),
+		});
+
+		this.logger.debug(`updated notesCount for user ${userId}: ${count}`);
+	}
+}

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -113,6 +113,25 @@ export type PostScheduledNoteJobData = {
 	noteDraftId: string;
 };
 
+export type NotePostJobData = {
+	noteId: MiNote['id'];
+	silent: boolean;
+};
+
+export type NoteDeleteJobData = {
+	noteId: string;
+	quiet: boolean;
+	userSnapshot: { id: string; uri: string | null; host: string | null; isBot: boolean };
+	noteSnapshot: Pick<MiNote, 'id' | 'userId' | 'userHost' | 'visibility' | 'localOnly' | 'channelId' | 'replyId' | 'renoteId' | 'fileIds'>;
+	apContent: any | null;
+	apRecipientIds: string[];
+	isRemote: boolean;
+};
+
+export type UpdateUserNotesCountJobData = {
+	userId: string;
+};
+
 export type SystemWebhookDeliverJobData<T extends SystemWebhookEventType = SystemWebhookEventType> = {
 	type: T;
 	content: SystemWebhookPayload<T>;


### PR DESCRIPTION
## 機能の説明

これまで `NoteCreateService` 内で同期的に行っていたノート投稿後の後処理 (配信・通知・カウンタ更新・削除処理など) を、ジョブキューに切り出して非同期実行するようにしました。

主な変更点:

- `NoteCreateService` を大幅にスリム化 (約 700 行削減)、投稿後の重い処理を `NoteProcessorService` / `NoteDeleteProcessorService` / `UpdateUserNotesCountProcessorService` に移管
- 通知制御を `NoteNotificationManagerService` に集約
- 新規キュー定義 (`note` / `noteDelete`) を追加し、`QueueProcessorService` から実行
- `NoteDeleteService` のロジックもジョブキュー経由に整理

## 利点

- ノート投稿 API のレスポンスタイムを短縮 (重い後処理を待たずに即時応答)
- 配信遅延・通知遅延が他リクエストを巻き込みにくくなり、**全体のスループットが向上**
- 配信失敗時のリトライ・可視化がジョブキュー基盤に乗ることで運用しやすくなる
- ノート投稿フローの責務分離により保守性が向上

#62 (ジョブキュー基盤を mokuroku-js へ移行) を前提として成立する独自機能です。