### PR TITLE
[機能紹介] 複数HTTPサーバプロセスの起動サポート

### DIFF
--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -197,6 +197,33 @@ id: 'aidx'
 # Number of threads of extra thread pool for CPU-intensive tasks (per worker)
 #threadPoolSize: 1
 
+# Cluster configuration
+#cluster:
+# ---------------------------------------------------------
+# This setting determines the role of worker processes.
+# Roles refer to the HTTP server (Web API server) function and the Job Queue function.
+# You can configure how many worker processes should be started for each role, such as two worker processes for the HTTP server role and four for the Job Queue role.
+#
+# The workers setting is an array of the following objects:
+#   name: The name of the worker process (optional).
+#   instances: The number of worker processes to start for this configuration. The total of these values must not exceed the clusterLimit setting.
+#   type: Specifies the role of the worker process. Available options are http and jobQueue. Since this is an array, a worker process can have multiple roles.
+# ---------------------------------------------------------
+#  workers:
+#    - name: http worker
+#      instances: 2
+#      type:
+#        - http
+#    - name: jobQueue worker
+#      instances: 4
+#      type:
+#        - jobQueue
+#    - name: both worker
+#      instances: 2
+#      type:
+#        - http
+#        - jobQueue
+
 # Job concurrency per worker
 # deliverJobConcurrency: 128
 # inboxJobConcurrency: 16

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -331,6 +331,33 @@ id: 'aidx'
 # Number of threads of extra thread pool for CPU-intensive tasks (per worker)
 #threadPoolSize: 1
 
+# Cluster configuration
+#cluster:
+# ---------------------------------------------------------
+# This setting determines the role of worker processes.
+# Roles refer to the HTTP server (Web API server) function and the Job Queue function.
+# You can configure how many worker processes should be started for each role, such as two worker processes for the HTTP server role and four for the Job Queue role.
+#
+# The workers setting is an array of the following objects:
+#   name: The name of the worker process (optional).
+#   instances: The number of worker processes to start for this configuration. The total of these values must not exceed the clusterLimit setting.
+#   type: Specifies the role of the worker process. Available options are http and jobQueue. Since this is an array, a worker process can have multiple roles.
+# ---------------------------------------------------------
+#  workers:
+#    - name: http worker
+#      instances: 2
+#      type:
+#        - http
+#    - name: jobQueue worker
+#      instances: 4
+#      type:
+#        - jobQueue
+#    - name: both worker
+#      instances: 2
+#      type:
+#        - http
+#        - jobQueue
+
 # Job concurrency per worker
 #deliverJobConcurrency: 128
 #inboxJobConcurrency: 16

--- a/packages/backend/src/boot/cluster.ts
+++ b/packages/backend/src/boot/cluster.ts
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import cluster from 'node:cluster';
+import type { Worker } from 'node:cluster';
+import type { WorkerArguments } from '@/boot/const.js';
+
+type ForkWorker = (env?: WorkerArguments) => Worker;
+
+const forkWorker = cluster.fork as unknown as ForkWorker;
+const workerArgumentsById = new Map<number, WorkerArguments>();
+
+export function registerWorkerArguments(workerId: number, args: WorkerArguments): void {
+	workerArgumentsById.set(workerId, { ...args });
+}
+
+export function forkConfiguredWorker(args: WorkerArguments, fork: ForkWorker = forkWorker): Worker {
+	const worker = fork(args);
+	registerWorkerArguments(worker.id, args);
+	return worker;
+}
+
+export function forkReplacementWorker(worker: Worker, fork: ForkWorker = forkWorker): Worker {
+	const args = workerArgumentsById.get(worker.id);
+	workerArgumentsById.delete(worker.id);
+	if (!args) {
+		return fork();
+	}
+
+	return forkConfiguredWorker(args, fork);
+}

--- a/packages/backend/src/boot/common.ts
+++ b/packages/backend/src/boot/common.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import os from 'node:os';
+import * as process from 'node:process';
 import { NestFactory } from '@nestjs/core';
 import { init } from 'slacc';
 import { NestLogger } from '@/NestLogger.js';
@@ -21,7 +23,8 @@ export function initExtraThreadPool(config: Config) {
 	slaccInitialized = true;
 }
 
-export async function server() {
+export async function server(options: { startStatsDaemons?: boolean } = {}) {
+	const startStatsDaemons = options.startStatsDaemons ?? true;
 	const { MainModule } = await import('../MainModule.js');
 	const { ServerService } = await import('../server/ServerService.js');
 
@@ -38,12 +41,15 @@ export async function server() {
 
 	if (process.env.NODE_ENV !== 'test') {
 		const { ChartManagementService } = await import('../core/chart/ChartManagementService.js');
-		const { QueueStatsService } = await import('../daemons/QueueStatsService.js');
-		const { ServerStatsService } = await import('../daemons/ServerStatsService.js');
 
 		app.get(ChartManagementService).start();
-		app.get(QueueStatsService).start();
-		app.get(ServerStatsService).start();
+		if (startStatsDaemons) {
+			const { QueueStatsService } = await import('../daemons/QueueStatsService.js');
+			const { ServerStatsService } = await import('../daemons/ServerStatsService.js');
+
+			app.get(QueueStatsService).start();
+			app.get(ServerStatsService).start();
+		}
 	}
 
 	return app;
@@ -67,3 +73,40 @@ export async function jobQueue() {
 
 	return jobQueue;
 }
+
+export function actualClusterLimit(config: Partial<Config>): number {
+	return Math.min(config.clusterLimit ?? 1, cpuCount);
+}
+
+/** メインプロセス上でHTTPサーバモジュールを動作させるべきかを判断する */
+export function isHttpServerOnPrimary(config: Partial<Config>): boolean {
+	const actualLimit = actualClusterLimit(config);
+	if (actualLimit === 1) {
+		// - クラスタ数の設定が無い（デフォルト値1を使用）
+		// - クラスタ数の設定が存在するものの、値が1である
+		// - そもそもCPUコアが1つしかない
+		return true;
+	}
+
+	if (!config.cluster?.workers || config.cluster.workers.length === 0) {
+		// - ワーカーの構成が無い
+		return true;
+	}
+
+	// ワーカーの構成が存在する＋httpサーバ用プロセスとする設定が1つ以下のようなケースも考えられるが、ケアしない
+	// （明示的にそのようなconfigを記述しているので、挙動を理解したうえでの設定と判断する）
+	return false;
+}
+
+// for testing
+export function setCpuCount(count: number): void {
+	// だいぶ苦肉の策だが、jestで上手くmockできないためこのような実装になっている
+	if (process.env.NODE_ENV !== 'test') {
+		throw new Error('This function is only available in test environment');
+	}
+
+	cpuCount = count;
+}
+
+// for testing
+let cpuCount = os.cpus().length;

--- a/packages/backend/src/boot/const.ts
+++ b/packages/backend/src/boot/const.ts
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+// 環境変数を経由するので名前の衝突を避けるためにアンダースコアを付ける
+export type WorkerArguments = {
+	__workerIndex: number;
+	__workerName?: string;
+	__moduleServer: boolean;
+	__moduleJobQueue: boolean;
+	__moduleStats: boolean;
+};

--- a/packages/backend/src/boot/entry.ts
+++ b/packages/backend/src/boot/entry.ts
@@ -11,6 +11,7 @@ import cluster from 'node:cluster';
 import { EventEmitter } from 'node:events';
 import chalk from 'chalk';
 import Xev from 'xev';
+import { forkReplacementWorker } from '@/boot/cluster.js';
 import Logger from '@/logger.js';
 import { envOption } from '../env.js';
 import { readyRef } from './ready.js';
@@ -18,8 +19,6 @@ import { runLocalShutdown } from './shutdown.js';
 import type { Worker } from 'node:cluster';
 
 import 'reflect-metadata';
-
-process.title = `Misskey (${cluster.isPrimary ? 'master' : 'worker'})`;
 
 Error.stackTraceLimit = Infinity;
 EventEmitter.defaultMaxListeners = 128;
@@ -137,7 +136,7 @@ cluster.on('exit', worker => {
 	// Replace the dead worker,
 	// we're not sentimental
 	clusterLogger.error(chalk.red(`[${worker.id}] died :(`));
-	cluster.fork();
+	forkReplacementWorker(worker);
 });
 
 process.once('SIGINT', () => void beginShutdown('SIGINT'));
@@ -168,12 +167,17 @@ if (!envOption.disableClustering) {
 	if (cluster.isPrimary) {
 		logger.info(`Start main process... pid: ${process.pid}`);
 		const { masterMain } = await import('./master.js');
+		process.title = 'Misskey (master)';
 		await masterMain();
 		ev.mount();
 	} else if (cluster.isWorker) {
 		logger.info(`Start worker process... pid: ${process.pid}`);
-		const { workerMain } = await import('./worker.js');
-		await workerMain();
+		const { workerMain, parseWorkerArguments } = await import('./worker.js');
+
+		const workerArguments = parseWorkerArguments(process.env);
+		process.title = `Misskey (worker${workerArguments.__workerName ? `: ${workerArguments.__workerName}` : ''})`;
+
+		await workerMain(workerArguments);
 	} else {
 		throw new Error('Unknown process type');
 	}
@@ -181,6 +185,7 @@ if (!envOption.disableClustering) {
 	// 非clusterの場合はMasterのみが起動するため、Workerの処理は行わない(cluster.isWorker === trueの状態でこのブロックに来ることはない)
 	logger.info(`Start main process... pid: ${process.pid}`);
 	const { masterMain } = await import('./master.js');
+	process.title = 'Misskey (master)';
 	await masterMain();
 	ev.mount();
 }

--- a/packages/backend/src/boot/master.ts
+++ b/packages/backend/src/boot/master.ts
@@ -5,15 +5,18 @@
 
 import * as fs from 'node:fs';
 import * as os from 'node:os';
-import cluster from 'node:cluster';
 import chalk from 'chalk';
 import chalkTemplate from 'chalk-template';
+import { forkConfiguredWorker } from '@/boot/cluster.js';
+import { WorkerArguments } from '@/boot/const.js';
+import { sentryInit } from '@/boot/sentry.js';
+import { computeWorkerArguments } from '@/boot/worker.js';
 import Logger from '@/logger.js';
 import { loadConfig } from '@/config.js';
 import type { Config } from '@/config.js';
 import { showMachineInfo } from '@/misc/show-machine-info.js';
 import { envOption } from '@/env.js';
-import { initExtraThreadPool, jobQueue, server } from './common.js';
+import { isHttpServerOnPrimary, initExtraThreadPool, jobQueue, server } from './common.js';
 
 const logger = new Logger('core', 'cyan');
 const bootLogger = logger.createSubLogger('boot', 'magenta');
@@ -66,26 +69,7 @@ export async function masterMain() {
 
 	initExtraThreadPool(config);
 
-	if (config.sentryForBackend) {
-		const Sentry = await import('@sentry/node');
-		const { nodeProfilingIntegration } = await import('@sentry/profiling-node');
-
-		Sentry.init({
-			integrations: [
-				...(config.sentryForBackend.enableNodeProfiling ? [nodeProfilingIntegration()] : []),
-			],
-
-			// Performance Monitoring
-			tracesSampleRate: 1.0, //  Capture 100% of the transactions
-
-			// Set sampling rate for profiling - this is relative to tracesSampleRate
-			profilesSampleRate: 1.0,
-
-			maxBreadcrumbs: 0,
-
-			...config.sentryForBackend.options,
-		});
-	}
+	await sentryInit(config);
 
 	bootLogger.info(
 		`mode: [disableClustering: ${envOption.disableClustering}, onlyServer: ${envOption.onlyServer}, onlyQueue: ${envOption.onlyQueue}]`,
@@ -94,8 +78,8 @@ export async function masterMain() {
 	if (!envOption.disableClustering) {
 		// clusterモジュール有効時
 
-		if (envOption.onlyServer) {
-			// onlyServer かつ enableCluster な場合、メインプロセスはforkのみに制限する(listenしない)。
+		if (envOption.onlyServer || !isHttpServerOnPrimary(config)) {
+			// このブロックに入る場合はワーカープロセス側でのlistenが必要になると判断されているため、メインプロセスはforkのみに制限する(listenしない)。
 			// ワーカープロセス側でlistenすると、メインプロセスでポートへの着信を受け入れてワーカープロセスへの分配を行う動作をする。
 			// そのため、メインプロセスでも直接listenするとポートの競合が発生して起動に失敗してしまう。
 			// see: https://nodejs.org/api/cluster.html#cluster
@@ -105,7 +89,7 @@ export async function masterMain() {
 			await server();
 		}
 
-		await spawnWorkers(config.clusterLimit);
+		await spawnWorkers(config);
 	} else {
 		// clusterモジュール無効時
 
@@ -183,16 +167,20 @@ async function connectDb(): Promise<void> {
 }
 */
 
-async function spawnWorkers(limit = 1) {
-	const workers = Math.min(limit, os.cpus().length);
-	bootLogger.info(`Starting ${workers} worker${workers === 1 ? '' : 's'}...`);
-	await Promise.all([...Array(workers)].map(spawnWorker));
+async function spawnWorkers(config: Config) {
+	const workerArgs = computeWorkerArguments(config, envOption);
+	bootLogger.info(`Starting ${workerArgs.length} worker${workerArgs.length === 1 ? '' : 's'}...`);
+
+	await Promise.all(
+		workerArgs.map(it => spawnWorker(it)),
+	);
+
 	bootLogger.succ('All workers started');
 }
 
-function spawnWorker(): Promise<void> {
+function spawnWorker(env: WorkerArguments): Promise<void> {
 	return new Promise(res => {
-		const worker = cluster.fork();
+		const worker = forkConfiguredWorker(env);
 		worker.on('message', message => {
 			if (message === 'listenFailed') {
 				bootLogger.error('The server Listen failed due to the previous error.');

--- a/packages/backend/src/boot/sentry.ts
+++ b/packages/backend/src/boot/sentry.ts
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { Config } from '@/config.js';
+
+export async function sentryInit(config: Config): Promise<void> {
+	if (!config.sentryForBackend) {
+		return;
+	}
+
+	const Sentry = await import('@sentry/node');
+	const integrations = config.sentryForBackend.enableNodeProfiling
+		? [(await import('@sentry/profiling-node')).nodeProfilingIntegration()]
+		: [];
+
+	Sentry.init({
+		integrations,
+
+		// Performance Monitoring
+		tracesSampleRate: 1.0, //  Capture 100% of the transactions
+
+		// Set sampling rate for profiling - this is relative to tracesSampleRate
+		profilesSampleRate: 1.0,
+
+		maxBreadcrumbs: 0,
+
+		...config.sentryForBackend.options,
+	});
+}

--- a/packages/backend/src/boot/worker.ts
+++ b/packages/backend/src/boot/worker.ts
@@ -5,43 +5,26 @@
 
 import cluster from 'node:cluster';
 import { envOption } from '@/env.js';
-import { loadConfig } from '@/config.js';
-import { initExtraThreadPool, jobQueue, server } from './common.js';
+import { WorkerArguments } from '@/boot/const.js';
+import { sentryInit } from '@/boot/sentry.js';
+import { ClusterWorkerType, Config, loadConfig } from '@/config.js';
+import { actualClusterLimit, isHttpServerOnPrimary, initExtraThreadPool, jobQueue, server } from './common.js';
 
 /**
  * Init worker process
  */
-export async function workerMain() {
+export async function workerMain(args: WorkerArguments) {
 	const config = loadConfig();
 
 	initExtraThreadPool(config);
 
-	if (config.sentryForBackend) {
-		const Sentry = await import('@sentry/node');
-		const { nodeProfilingIntegration } = await import('@sentry/profiling-node');
+	await sentryInit(config);
 
-		Sentry.init({
-			integrations: [
-				...(config.sentryForBackend.enableNodeProfiling ? [nodeProfilingIntegration()] : []),
-			],
-
-			// Performance Monitoring
-			tracesSampleRate: 1.0, //  Capture 100% of the transactions
-
-			// Set sampling rate for profiling - this is relative to tracesSampleRate
-			profilesSampleRate: 1.0,
-
-			maxBreadcrumbs: 0,
-
-			...config.sentryForBackend.options,
-		});
+	if (args.__moduleServer) {
+		await server({ startStatsDaemons: args.__moduleStats });
 	}
 
-	if (envOption.onlyServer) {
-		await server();
-	} else if (envOption.onlyQueue) {
-		await jobQueue();
-	} else {
+	if (args.__moduleJobQueue) {
 		await jobQueue();
 	}
 
@@ -49,4 +32,101 @@ export async function workerMain() {
 		// Send a 'ready' message to parent process
 		process.send?.('ready');
 	}
+}
+
+type WorkerSetting = {
+	name?: string;
+	type: ClusterWorkerType[];
+};
+
+export function computeWorkerArguments(config: Partial<Config>, envs: Partial<typeof envOption>): WorkerArguments[] {
+	const clusterCount = actualClusterLimit(config);
+
+	if (envs.onlyQueue && envs.onlyServer) {
+		throw new Error('Cannot specify both onlyQueue and onlyServer');
+	} else if (envs.onlyQueue) {
+		// ぜんぶJobQueue
+		return Array.from({ length: clusterCount }, (_, idx) => ({
+			__workerName: 'job-queue',
+			__workerIndex: idx,
+			__moduleServer: false,
+			__moduleJobQueue: true,
+			__moduleStats: false,
+		}));
+	} else if (envs.onlyServer) {
+		// ぜんぶServer
+		return Array.from({ length: clusterCount }, (_, idx) => ({
+			__workerName: 'http-server',
+			__workerIndex: idx,
+			__moduleServer: true,
+			__moduleJobQueue: false,
+			__moduleStats: idx === 0,
+		}));
+	} else if (isHttpServerOnPrimary(config)) {
+		// メインプロセス上でHTTPサーバモジュールを動作させるconfig構成である場合、ワーカー側にはHTTPサーバの設定をしない
+		return Array.from({ length: clusterCount }).map((_, idx) => ({
+			__workerName: 'job-queue',
+			__workerIndex: idx,
+			__moduleServer: false,
+			__moduleJobQueue: true,
+			__moduleStats: false,
+		}));
+	}
+
+	// 扱いやすいようにWorkerの設定を展開
+	const workerSettings: WorkerSetting[] = [];
+	for (const worker of config.cluster?.workers ?? []) {
+		for (let i = 0; i < worker.instances; i++) {
+			workerSettings.push({
+				name: worker.name,
+				type: worker.type,
+			});
+		}
+	}
+
+	if (workerSettings.length < clusterCount) {
+		// Workerの設定が足りない場合はデフォルト値で埋める
+		for (let i = workerSettings.length; i < clusterCount; i++) {
+			workerSettings.push({
+				name: 'job-queue',
+				type: ['jobQueue'],
+			});
+		}
+	} else if (workerSettings.length > clusterCount) {
+		// 何を削っていいかわからないのでWorkerの設定が多いときはエラーにする
+		throw new Error('Too many worker settings');
+	}
+
+	let hasStatsWorker = false;
+	const result = workerSettings.map((it, idx) => {
+		const moduleServer = it.type.includes('http');
+		const moduleStats = moduleServer && !hasStatsWorker;
+		if (moduleStats) {
+			hasStatsWorker = true;
+		}
+
+		return {
+			__workerIndex: idx,
+			__workerName: it.name,
+			__moduleServer: moduleServer,
+			__moduleJobQueue: it.type.includes('jobQueue'),
+			__moduleStats: moduleStats,
+		};
+	});
+
+	if (!result.some(it => it.__moduleServer)) {
+		throw new Error('No HTTP server worker configured');
+	}
+
+	return result;
+}
+
+export function parseWorkerArguments(args: Record<string, unknown>): WorkerArguments {
+	return {
+		__workerIndex: Number(args.__workerIndex),
+		__workerName: args.__workerName ? args.__workerName.toString() : undefined,
+		__moduleServer: args.__moduleServer === 'true' || args.__moduleServer === true,
+		__moduleJobQueue: args.__moduleJobQueue === 'true' || args.__moduleJobQueue === true,
+		__moduleStats: args.__moduleStats === 'true' || args.__moduleStats === true,
+	};
 }

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -86,6 +86,9 @@ type Source = {
 
 	clusterLimit?: number;
 	threadPoolSize?: number;
+	cluster?: {
+		workers: ClusterWorker[]
+	};
 
 	id: string;
 
@@ -160,6 +163,9 @@ export type Config = {
 	maxFileSize: number;
 	clusterLimit: number | undefined;
 	threadPoolSize: number;
+	cluster?: {
+		workers: ClusterWorker[]
+	};
 	id: string;
 	outgoingAddress: string | undefined;
 	outgoingAddressFamily: 'ipv4' | 'ipv6' | 'dual' | undefined;
@@ -215,6 +221,13 @@ export type Config = {
 };
 
 export type FulltextSearchProvider = 'sqlLike' | 'sqlPgroonga' | 'meilisearch';
+
+export type ClusterWorkerType = 'http' | 'jobQueue';
+export type ClusterWorker = {
+	name?: string;
+	instances: number;
+	type: ClusterWorkerType[];
+};
 
 const _filename = fileURLToPath(import.meta.url);
 const _dirname = dirname(_filename);
@@ -316,6 +329,7 @@ export function loadConfig(): Config {
 		maxFileSize: config.maxFileSize ?? 262144000,
 		clusterLimit: config.clusterLimit,
 		threadPoolSize: config.threadPoolSize ?? 1,
+		cluster: config.cluster,
 		outgoingAddress: config.outgoingAddress,
 		outgoingAddressFamily: config.outgoingAddressFamily,
 		deliverJobConcurrency: config.deliverJobConcurrency,

--- a/packages/backend/test/unit/boot/cluster.ts
+++ b/packages/backend/test/unit/boot/cluster.ts
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import type { Worker } from 'node:cluster';
+import { describe, expect, test, vi } from 'vitest';
+import { forkReplacementWorker, registerWorkerArguments } from '@/boot/cluster.js';
+import type { WorkerArguments } from '@/boot/const.js';
+
+describe('cluster', () => {
+	test('workerの再起動時に元のworker引数を引き継ぐ', () => {
+		const args: WorkerArguments = {
+			__workerIndex: 1,
+			__workerName: 'http-server',
+			__moduleServer: true,
+			__moduleJobQueue: false,
+			__moduleStats: true,
+		};
+		const replacement = { id: 99 } as Worker;
+		const fork = vi.fn(() => replacement);
+
+		registerWorkerArguments(12, args);
+		const result = forkReplacementWorker({ id: 12 } as Worker, fork);
+
+		expect(result).toBe(replacement);
+		expect(fork).toHaveBeenCalledWith(args);
+	});
+
+	test('引数を保持していないworkerは従来通り引数なしで再起動する', () => {
+		const replacement = { id: 100 } as Worker;
+		const fork = vi.fn(() => replacement);
+
+		const result = forkReplacementWorker({ id: 13 } as Worker, fork);
+
+		expect(result).toBe(replacement);
+		expect(fork).toHaveBeenCalledWith();
+	});
+});

--- a/packages/backend/test/unit/boot/sentry.ts
+++ b/packages/backend/test/unit/boot/sentry.ts
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Config } from '@/config.js';
+
+const mock = vi.hoisted(() => ({
+	sentryImportCount: 0,
+	profilingImportCount: 0,
+	init: vi.fn(),
+	nodeProfilingIntegration: vi.fn(),
+}));
+
+vi.mock('@sentry/node', () => {
+	mock.sentryImportCount++;
+	return {
+		init: mock.init,
+	};
+});
+
+vi.mock('@sentry/profiling-node', () => {
+	mock.profilingImportCount++;
+	return {
+		nodeProfilingIntegration: mock.nodeProfilingIntegration,
+	};
+});
+
+describe('sentryInit', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mock.sentryImportCount = 0;
+		mock.profilingImportCount = 0;
+		mock.init.mockReset();
+		mock.nodeProfilingIntegration.mockReset();
+	});
+
+	test('sentryForBackendが未設定の場合はSentry関連モジュールを読み込まない', async () => {
+		const { sentryInit } = await import('@/boot/sentry.js');
+
+		await sentryInit({ sentryForBackend: undefined } as Config);
+
+		expect(mock.sentryImportCount).toBe(0);
+		expect(mock.profilingImportCount).toBe(0);
+		expect(mock.init).not.toHaveBeenCalled();
+	});
+});

--- a/packages/backend/test/unit/boot/worker.ts
+++ b/packages/backend/test/unit/boot/worker.ts
@@ -1,0 +1,218 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { beforeEach, describe, expect, test } from 'vitest';
+import { setCpuCount } from '@/boot/common.js';
+import { computeWorkerArguments } from '@/boot/worker.js';
+import type { WorkerArguments } from '@/boot/const.js';
+import type { ClusterWorker, Config } from '@/config.js';
+
+describe('worker', () => {
+	beforeEach(() => {
+		setCpuCount(4);
+	});
+
+	describe('computeWorkerArguments', () => {
+		function createConfig(cfg: {
+			clusterLimit?: number;
+			workers?: ClusterWorker[];
+		}): Partial<Config> {
+			return {
+				clusterLimit: cfg.clusterLimit,
+				cluster: cfg.workers ? { workers: cfg.workers } : undefined,
+			};
+		}
+
+		describe('onlyServer, onlyQueueによる判定確認', () => {
+			test('onlyServer === trueの時は全部の __moduleServer がtrue', () => {
+				const config = createConfig({
+					clusterLimit: 4,
+				});
+				const envs = { onlyServer: true };
+
+				const result = computeWorkerArguments(config, envs);
+
+				expect(result.length).toBe(4);
+				for (const r of result) {
+					expect(r.__moduleServer).toBe(true);
+					expect(r.__moduleJobQueue).toBe(false);
+				}
+				expect(result.filter(r => r.__moduleStats).length).toBe(1);
+				expect(result[0].__moduleStats).toBe(true);
+			});
+
+			test('onlyQueue === trueの時は全部の __moduleJobQueue がtrue', () => {
+				const config = createConfig({
+					clusterLimit: 4,
+				});
+				const envs = { onlyQueue: true };
+
+				const result = computeWorkerArguments(config, envs);
+
+				expect(result.length).toBe(4);
+				for (const r of result) {
+					expect(r.__moduleServer).toBe(false);
+					expect(r.__moduleJobQueue).toBe(true);
+					expect(r.__moduleStats).toBe(false);
+				}
+			});
+
+			test('onlyQueue === true, onlyServer === trueの時は不正な設定値としてエラー', () => {
+				const config = createConfig({
+					clusterLimit: 4,
+				});
+				const envs = { onlyServer: true, onlyQueue: true };
+
+				expect(() => computeWorkerArguments(config, envs))
+					.toThrow('Cannot specify both onlyQueue and onlyServer');
+			});
+		});
+
+		describe('メインプロセスでHTTPサーバを起動し、全てのワーカープロセスでJobQueueを起動する構成', () => {
+			function assertWorkerArguments(actual: WorkerArguments[], clusterLimit: number): void {
+				expect(actual.length).toBe(clusterLimit);
+				for (let i = 0; i < clusterLimit; i++) {
+					expect(actual[i].__moduleServer).toBe(false);
+					expect(actual[i].__moduleJobQueue).toBe(true);
+					expect(actual[i].__moduleStats).toBe(false);
+				}
+			}
+
+			test('clusterLimitが未設定の場合', () => {
+				const config = createConfig({});
+				const result = computeWorkerArguments(config, {});
+				assertWorkerArguments(result, 1);
+			});
+
+			test('clusterLimitが1の場合', () => {
+				const config = createConfig({
+					clusterLimit: 1,
+				});
+				const result = computeWorkerArguments(config, {});
+				assertWorkerArguments(result, 1);
+			});
+
+			test('clusterLimitは4だがCPUコア数が1の場合', () => {
+				setCpuCount(1);
+				const config = createConfig({
+					clusterLimit: 4,
+				});
+				const result = computeWorkerArguments(config, {});
+				assertWorkerArguments(result, 1);
+			});
+
+			test('cluster.workersが未設定の場合①', () => {
+				const config = createConfig({
+					clusterLimit: 4,
+				});
+				const result = computeWorkerArguments(config, {});
+				assertWorkerArguments(result, 4);
+			});
+
+			test('cluster.workersが未設定の場合②', () => {
+				const config = createConfig({
+					clusterLimit: 4,
+					workers: [],
+				});
+				const result = computeWorkerArguments(config, {});
+				assertWorkerArguments(result, 4);
+			});
+		});
+
+		describe('cluster.workersに設定された内容に従ってWorkerArgumentsを生成する', () => {
+			test('cluster.workersどおりの構成で生成できるか', () => {
+				setCpuCount(8);
+				const config = createConfig({
+					clusterLimit: 8,
+					workers: [
+						{
+							instances: 2,
+							type: ['http'],
+						}, {
+							instances: 4,
+							type: ['jobQueue'],
+						}, {
+							instances: 2,
+							type: ['jobQueue', 'http'],
+						},
+					],
+				});
+
+				const result = computeWorkerArguments(config, {});
+				expect(result.length).toBe(8);
+				expect(result[0].__moduleServer).toBe(true);
+				expect(result[0].__moduleJobQueue).toBe(false);
+				expect(result[0].__moduleStats).toBe(true);
+				expect(result[1].__moduleServer).toBe(true);
+				expect(result[1].__moduleJobQueue).toBe(false);
+				expect(result[1].__moduleStats).toBe(false);
+				for (let i = 2; i < 6; i++) {
+					expect(result[i].__moduleServer).toBe(false);
+					expect(result[i].__moduleJobQueue).toBe(true);
+					expect(result[i].__moduleStats).toBe(false);
+				}
+				for (let i = 6; i < 8; i++) {
+					expect(result[i].__moduleServer).toBe(true);
+					expect(result[i].__moduleJobQueue).toBe(true);
+					expect(result[i].__moduleStats).toBe(false);
+				}
+			});
+
+			test('clusterLimitに対しcluster.workersの要素数が足りない場合はデフォルト値(jobQueue)で埋める', () => {
+				const config = createConfig({
+					clusterLimit: 4,
+					workers: [{
+						name: 'http-server',
+						instances: 1,
+						type: ['http'],
+					}],
+				});
+
+				const result = computeWorkerArguments(config, {});
+				expect(result.length).toBe(4);
+				expect(result[0].__moduleServer).toBe(true);
+				expect(result[0].__moduleJobQueue).toBe(false);
+				expect(result[0].__moduleStats).toBe(true);
+				for (let i = 1; i < 4; i++) {
+					expect(result[i].__moduleServer).toBe(false);
+					expect(result[i].__moduleJobQueue).toBe(true);
+					expect(result[i].__moduleStats).toBe(false);
+				}
+			});
+
+			test('cluster.workersの数よりもclusterLimitが少ない場合はエラー', () => {
+				const config = createConfig({
+					clusterLimit: 2,
+					workers: [{
+						name: 'http-server',
+						instances: 1,
+						type: ['http'],
+					}, {
+						name: 'job-queue',
+						instances: 2,
+						type: ['jobQueue'],
+					}],
+				});
+
+				expect(() => computeWorkerArguments(config, {}))
+					.toThrow('Too many worker settings');
+			});
+
+			test('通常起動でHTTPサーバ用workerが存在しない場合はエラー', () => {
+				const config = createConfig({
+					clusterLimit: 2,
+					workers: [{
+						name: 'job-queue',
+						instances: 2,
+						type: ['jobQueue'],
+					}],
+				});
+
+				expect(() => computeWorkerArguments(config, {}))
+					.toThrow('No HTTP server worker configured');
+			});
+		});
+	});
+});


### PR DESCRIPTION
## 機能の説明

1 つの Misskey インスタンス上で、ワーカープロセスごとに **HTTP サーバ役** と **Job Queue 役** を個別に割り当てて起動できるようにする機能です。
従来は `clusterLimit` で起動するワーカー全体が HTTP + Job Queue の両方を担う構成でしたが、`.config/default.yml` の新規 `cluster.workers` セクションで以下のように役割と起動数を分けて指定できます。

```yaml
cluster:
  workers:
    - name: http worker
      instances: 2
      type:
        - http
    - name: jobQueue worker
      instances: 4
      type:
        - jobQueue
    - name: both worker
      instances: 2
      type:
        - http
        - jobQueue
```

## 利点

- HTTP リクエスト処理能力と Job Queue 処理能力を **役割ごとに独立してスケール**できる
- リソース特性 (CPU バウンドな配送ジョブ / I/O バウンドな API) に合わせた配分が可能
- 大規模インスタンスでの安定運用に寄与する

本家 (misskey-dev/misskey) でも PR #13662 として提案中の機能の先行実装版です。