### PR TITLE
[機能紹介] いくつかの処理を JobQueue 化

### DIFF
--- a/packages/backend/src/core/NotePiningService.ts
+++ b/packages/backend/src/core/NotePiningService.ts
@@ -11,13 +11,12 @@ import type { MiUser } from '@/models/User.js';
 import type { MiNote } from '@/models/Note.js';
 import { IdService } from '@/core/IdService.js';
 import type { MiUserNotePining } from '@/models/UserNotePining.js';
-import { RelayService } from '@/core/RelayService.js';
 import type { Config } from '@/config.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
-import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
 import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
 import { bindThis } from '@/decorators.js';
 import { RoleService } from '@/core/RoleService.js';
+import { QueueService } from '@/core/QueueService.js';
 
 @Injectable()
 export class NotePiningService {
@@ -37,9 +36,8 @@ export class NotePiningService {
 		private userEntityService: UserEntityService,
 		private idService: IdService,
 		private roleService: RoleService,
-		private relayService: RelayService,
-		private apDeliverManagerService: ApDeliverManagerService,
 		private apRendererService: ApRendererService,
+		private queueService: QueueService,
 	) {
 	}
 
@@ -121,7 +119,11 @@ export class NotePiningService {
 		const item = `${this.config.url}/notes/${noteId}`;
 		const content = this.apRendererService.addContext(isAddition ? this.apRendererService.renderAdd(user, target, item) : this.apRendererService.renderRemove(user, target, item));
 
-		this.apDeliverManagerService.deliverToFollowers(user, content);
-		this.relayService.deliverToRelays(user, content);
+		this.queueService.notePiningDeliver({
+			noteId,
+			userSnapshot: { id: user.id },
+			apContent: content,
+			isAddition,
+		});
 	}
 }

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -49,13 +49,19 @@ import { endedPollNotificationJob } from '@/queue/jobs/definitions/misc.js';
 import { queueDefinitionFromType } from '@/queue/jobs/queueDefinitions.js';
 import { notePostJob, updateUserNotesCountJob } from '@/queue/jobs/definitions/note.js';
 import { noteDeleteJob } from '@/queue/jobs/definitions/noteDelete.js';
+import { reactionDeliverJob } from '@/queue/jobs/definitions/reactionDeliver.js';
+import { notePiningDeliverJob } from '@/queue/jobs/definitions/notePiningDeliver.js';
+import { instanceFollowStatsUpdateJob } from '@/queue/jobs/definitions/instanceFollowStatsUpdate.js';
 import { type UserWebhookPayload } from './UserWebhookService.js';
 import type * as Bull from 'bullmq';
 import type httpSignature from '@peertube/http-signature';
 import type {
 	DeliverJobData,
+	InstanceFollowStatsUpdateJobData,
 	SystemWebhookDeliverJobData,
 	NoteDeleteJobData,
+	NotePiningDeliverJobData,
+	ReactionDeliverJobData,
 	ThinUser,
 	UserWebhookDeliverJobData,
 } from '../queue/types.js';
@@ -441,6 +447,31 @@ export class QueueService {
 	}
 
 	@bindThis
+	public reactionDeliver(data: ReactionDeliverJobData) {
+		const suffix = data.isUndo ? 'undo' : 'create';
+		return this.jobRuntime.enqueue(
+			reactionDeliverJob,
+			data,
+			{ jobId: `reactionDeliver-${data.noteId}-${data.userSnapshot.id}-${suffix}` },
+		);
+	}
+
+	@bindThis
+	public notePiningDeliver(data: NotePiningDeliverJobData) {
+		const suffix = data.isAddition ? 'add' : 'remove';
+		return this.jobRuntime.enqueue(
+			notePiningDeliverJob,
+			data,
+			{ jobId: `notePiningDeliver-${data.noteId}-${data.userSnapshot.id}-${suffix}` },
+		);
+	}
+
+	@bindThis
+	public instanceFollowStatsUpdate(data: InstanceFollowStatsUpdateJobData) {
+		return this.jobRuntime.enqueue(instanceFollowStatsUpdateJob, data);
+	}
+
+	@bindThis
 	public updateUserNotesCount(userId: string) {
 		// 5 分以内の同一 userId 再 enqueue は BullMQ が既存 delayed ジョブを温存するため 1 回しか発火しない
 		return this.jobRuntime.enqueue(updateUserNotesCountJob, { userId }, {
@@ -507,7 +538,6 @@ export class QueueService {
 
 	@bindThis
 	private packJobData(job: Bull.Job): Packed<'QueueJob'> {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		const stacktrace = job.stacktrace ? job.stacktrace.filter(Boolean) : [];
 		stacktrace.reverse();
 

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -7,7 +7,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { DI } from '@/di-symbols.js';
 import type { EmojisRepository, NoteReactionsRepository, UsersRepository, NotesRepository, MiMeta } from '@/models/_.js';
 import { IdentifiableError } from '@/misc/identifiable-error.js';
-import type { MiRemoteUser, MiUser } from '@/models/User.js';
+import type { MiUser } from '@/models/User.js';
 import type { MiNote } from '@/models/Note.js';
 import { IdService } from '@/core/IdService.js';
 import type { MiNoteReaction } from '@/models/NoteReaction.js';
@@ -16,7 +16,6 @@ import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { NotificationService } from '@/core/NotificationService.js';
 import PerUserReactionsChart from '@/core/chart/charts/per-user-reactions.js';
 import { emojiRegex } from '@/misc/emoji-regex.js';
-import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
@@ -26,7 +25,7 @@ import { UserBlockingService } from '@/core/UserBlockingService.js';
 import { CustomEmojiService } from '@/core/CustomEmojiService.js';
 import { RoleService } from '@/core/RoleService.js';
 import { FeaturedService } from '@/core/FeaturedService.js';
-import { trackPromise } from '@/misc/promise-tracker.js';
+import { QueueService } from '@/core/QueueService.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
 import { ReactionsBufferingService } from '@/core/ReactionsBufferingService.js';
 import { PER_NOTE_REACTION_USER_PAIR_CACHE_MAX } from '@/const.js';
@@ -96,7 +95,7 @@ export class ReactionService {
 		private featuredService: FeaturedService,
 		private globalEventService: GlobalEventService,
 		private apRendererService: ApRendererService,
-		private apDeliverManagerService: ApDeliverManagerService,
+		private queueService: QueueService,
 		private notificationService: NotificationService,
 		private perUserReactionsChart: PerUserReactionsChart,
 	) {
@@ -264,23 +263,33 @@ export class ReactionService {
 
 		//#region 配信
 		if (this.userEntityService.isLocalUser(user) && !note.localOnly) {
-			const content = this.apRendererService.addContext(await this.apRendererService.renderLike(record, note));
-			const dm = this.apDeliverManagerService.createDeliverManager(user, content);
-			if (note.userHost !== null) {
-				const reactee = await this.usersRepository.findOneBy({ id: note.userId });
-				dm.addDirectRecipe(reactee as MiRemoteUser);
-			}
+			const apContent = this.apRendererService.addContext(
+				await this.apRendererService.renderLike(record, note),
+			);
 
-			if (['public', 'home', 'followers'].includes(note.visibility)) {
-				dm.addFollowersRecipe();
-			} else if (note.visibility === 'specified') {
-				const visibleUsers = await Promise.all(note.visibleUserIds.map(id => this.usersRepository.findOneBy({ id })));
-				for (const u of visibleUsers.filter(u => u && this.userEntityService.isRemoteUser(u))) {
-					dm.addDirectRecipe(u as MiRemoteUser);
+			const apRecipientIds: string[] = [];
+			if (note.userHost !== null) {
+				apRecipientIds.push(note.userId);
+			}
+			if (note.visibility === 'specified') {
+				const visibleUsers = await Promise.all(
+					note.visibleUserIds.map(id => this.usersRepository.findOneBy({ id })),
+				);
+				for (const u of visibleUsers) {
+					if (u && this.userEntityService.isRemoteUser(u)) {
+						apRecipientIds.push(u.id);
+					}
 				}
 			}
 
-			trackPromise(dm.execute());
+			this.queueService.reactionDeliver({
+				noteId: note.id,
+				userSnapshot: { id: user.id },
+				apContent,
+				apRecipientIds: [...new Set(apRecipientIds)],
+				isUndo: false,
+				deliverToFollowers: ['public', 'home', 'followers'].includes(note.visibility),
+			});
 		}
 		//#endregion
 	}
@@ -325,14 +334,26 @@ export class ReactionService {
 
 		//#region 配信
 		if (this.userEntityService.isLocalUser(user) && !note.localOnly) {
-			const content = this.apRendererService.addContext(this.apRendererService.renderUndo(await this.apRendererService.renderLike(exist, note), user));
-			const dm = this.apDeliverManagerService.createDeliverManager(user, content);
+			const apContent = this.apRendererService.addContext(
+				this.apRendererService.renderUndo(
+					await this.apRendererService.renderLike(exist, note),
+					user,
+				),
+			);
+
+			const apRecipientIds: string[] = [];
 			if (note.userHost !== null) {
-				const reactee = await this.usersRepository.findOneBy({ id: note.userId });
-				dm.addDirectRecipe(reactee as MiRemoteUser);
+				apRecipientIds.push(note.userId);
 			}
-			dm.addFollowersRecipe();
-			trackPromise(dm.execute());
+
+			this.queueService.reactionDeliver({
+				noteId: note.id,
+				userSnapshot: { id: user.id },
+				apContent,
+				apRecipientIds,
+				isUndo: true,
+				deliverToFollowers: true,
+			});
 		}
 		//#endregion
 	}

--- a/packages/backend/src/core/UserFollowingService.ts
+++ b/packages/backend/src/core/UserFollowingService.ts
@@ -13,12 +13,10 @@ import PerUserFollowingChart from '@/core/chart/charts/per-user-following.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { IdService } from '@/core/IdService.js';
 import { isDuplicateKeyValueError } from '@/misc/is-duplicate-key-value-error.js';
-import InstanceChart from '@/core/chart/charts/instance.js';
-import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { UserWebhookService } from '@/core/UserWebhookService.js';
 import { NotificationService } from '@/core/NotificationService.js';
 import { DI } from '@/di-symbols.js';
-import type { FollowingsRepository, FollowRequestsRepository, InstancesRepository, MiMeta, UserProfilesRepository, UsersRepository } from '@/models/_.js';
+import type { FollowingsRepository, FollowRequestsRepository, MiMeta, UserProfilesRepository, UsersRepository } from '@/models/_.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
 import { bindThis } from '@/decorators.js';
@@ -70,9 +68,6 @@ export class UserFollowingService implements OnModuleInit {
 		@Inject(DI.followRequestsRepository)
 		private followRequestsRepository: FollowRequestsRepository,
 
-		@Inject(DI.instancesRepository)
-		private instancesRepository: InstancesRepository,
-
 		private cacheService: CacheService,
 		private utilityService: UtilityService,
 		private userEntityService: UserEntityService,
@@ -80,12 +75,10 @@ export class UserFollowingService implements OnModuleInit {
 		private queueService: QueueService,
 		private globalEventService: GlobalEventService,
 		private notificationService: NotificationService,
-		private federatedInstanceService: FederatedInstanceService,
 		private webhookService: UserWebhookService,
 		private apRendererService: ApRendererService,
 		private accountMoveService: AccountMoveService,
 		private perUserFollowingChart: PerUserFollowingChart,
-		private instanceChart: InstanceChart,
 	) {
 	}
 
@@ -306,19 +299,20 @@ export class UserFollowingService implements OnModuleInit {
 
 			//#region Update instance stats
 			if (this.meta.enableStatsForFederatedInstances) {
+				const updateChart = this.meta.enableChartsForFederatedInstances;
 				if (this.userEntityService.isRemoteUser(follower) && this.userEntityService.isLocalUser(followee)) {
-					this.federatedInstanceService.fetchOrRegister(follower.host).then(async i => {
-						this.instancesRepository.increment({ id: i.id }, 'followingCount', 1);
-						if (this.meta.enableChartsForFederatedInstances) {
-							this.instanceChart.updateFollowing(i.host, true);
-						}
+					this.queueService.instanceFollowStatsUpdate({
+						host: follower.host,
+						direction: 'following',
+						isAdditional: true,
+						updateChart,
 					});
 				} else if (this.userEntityService.isLocalUser(follower) && this.userEntityService.isRemoteUser(followee)) {
-					this.federatedInstanceService.fetchOrRegister(followee.host).then(async i => {
-						this.instancesRepository.increment({ id: i.id }, 'followersCount', 1);
-						if (this.meta.enableChartsForFederatedInstances) {
-							this.instanceChart.updateFollowers(i.host, true);
-						}
+					this.queueService.instanceFollowStatsUpdate({
+						host: followee.host,
+						direction: 'followers',
+						isAdditional: true,
+						updateChart,
 					});
 				}
 			}
@@ -422,19 +416,20 @@ export class UserFollowingService implements OnModuleInit {
 
 			//#region Update instance stats
 			if (this.meta.enableStatsForFederatedInstances) {
+				const updateChart = this.meta.enableChartsForFederatedInstances;
 				if (this.userEntityService.isRemoteUser(follower) && this.userEntityService.isLocalUser(followee)) {
-					this.federatedInstanceService.fetchOrRegister(follower.host).then(async i => {
-						this.instancesRepository.decrement({ id: i.id }, 'followingCount', 1);
-						if (this.meta.enableChartsForFederatedInstances) {
-							this.instanceChart.updateFollowing(i.host, false);
-						}
+					this.queueService.instanceFollowStatsUpdate({
+						host: follower.host,
+						direction: 'following',
+						isAdditional: false,
+						updateChart,
 					});
 				} else if (this.userEntityService.isLocalUser(follower) && this.userEntityService.isRemoteUser(followee)) {
-					this.federatedInstanceService.fetchOrRegister(followee.host).then(async i => {
-						this.instancesRepository.decrement({ id: i.id }, 'followersCount', 1);
-						if (this.meta.enableChartsForFederatedInstances) {
-							this.instanceChart.updateFollowers(i.host, false);
-						}
+					this.queueService.instanceFollowStatsUpdate({
+						host: followee.host,
+						direction: 'followers',
+						isAdditional: false,
+						updateChart,
 					});
 				}
 			}

--- a/packages/backend/src/queue/QueueProcessorModule.ts
+++ b/packages/backend/src/queue/QueueProcessorModule.ts
@@ -14,6 +14,9 @@ import { PostScheduledNoteProcessorService } from './processors/PostScheduledNot
 import { InboxProcessorService } from './processors/InboxProcessorService.js';
 import { NoteProcessorService } from './processors/NoteProcessorService.js';
 import { NoteDeleteProcessorService } from './processors/NoteDeleteProcessorService.js';
+import { ReactionDeliverProcessorService } from './processors/ReactionDeliverProcessorService.js';
+import { NotePiningDeliverProcessorService } from './processors/NotePiningDeliverProcessorService.js';
+import { InstanceFollowStatsUpdateProcessorService } from './processors/InstanceFollowStatsUpdateProcessorService.js';
 import { UpdateUserNotesCountProcessorService } from './processors/UpdateUserNotesCountProcessorService.js';
 import { UserWebhookDeliverProcessorService } from './processors/UserWebhookDeliverProcessorService.js';
 import { SystemWebhookDeliverProcessorService } from './processors/SystemWebhookDeliverProcessorService.js';
@@ -88,6 +91,9 @@ import { RelationshipProcessorService } from './processors/RelationshipProcessor
 		InboxProcessorService,
 		NoteProcessorService,
 		NoteDeleteProcessorService,
+		ReactionDeliverProcessorService,
+		NotePiningDeliverProcessorService,
+		InstanceFollowStatsUpdateProcessorService,
 		UpdateUserNotesCountProcessorService,
 		AggregateRetentionProcessorService,
 		CheckExpiredMutingsProcessorService,

--- a/packages/backend/src/queue/QueueProcessorService.ts
+++ b/packages/backend/src/queue/QueueProcessorService.ts
@@ -49,6 +49,15 @@ import {
 	noteDeleteJob,
 } from '@/queue/jobs/definitions/noteDelete.js';
 import {
+	reactionDeliverJob,
+} from '@/queue/jobs/definitions/reactionDeliver.js';
+import {
+	notePiningDeliverJob,
+} from '@/queue/jobs/definitions/notePiningDeliver.js';
+import {
+	instanceFollowStatsUpdateJob,
+} from '@/queue/jobs/definitions/instanceFollowStatsUpdate.js';
+import {
 	cleanRemoteFilesJob,
 	deleteFileJob,
 } from '@/queue/jobs/definitions/objectStorage.js';
@@ -105,6 +114,9 @@ import { ImportUserListsProcessorService } from './processors/ImportUserListsPro
 import { InboxProcessorService } from './processors/InboxProcessorService.js';
 import { NoteProcessorService } from './processors/NoteProcessorService.js';
 import { NoteDeleteProcessorService } from './processors/NoteDeleteProcessorService.js';
+import { ReactionDeliverProcessorService } from './processors/ReactionDeliverProcessorService.js';
+import { NotePiningDeliverProcessorService } from './processors/NotePiningDeliverProcessorService.js';
+import { InstanceFollowStatsUpdateProcessorService } from './processors/InstanceFollowStatsUpdateProcessorService.js';
 import { UpdateUserNotesCountProcessorService } from './processors/UpdateUserNotesCountProcessorService.js';
 import { PostScheduledNoteProcessorService } from './processors/PostScheduledNoteProcessorService.js';
 import { RelationshipProcessorService } from './processors/RelationshipProcessorService.js';
@@ -145,6 +157,9 @@ export class QueueProcessorService implements OnApplicationShutdown {
 		private postScheduledNoteProcessorService: PostScheduledNoteProcessorService,
 		private noteProcessorService: NoteProcessorService,
 		private noteDeleteProcessorService: NoteDeleteProcessorService,
+		private reactionDeliverProcessorService: ReactionDeliverProcessorService,
+		private notePiningDeliverProcessorService: NotePiningDeliverProcessorService,
+		private instanceFollowStatsUpdateProcessorService: InstanceFollowStatsUpdateProcessorService,
 		private updateUserNotesCountProcessorService: UpdateUserNotesCountProcessorService,
 		private deliverProcessorService: DeliverProcessorService,
 		private inboxProcessorService: InboxProcessorService,
@@ -385,6 +400,30 @@ export class QueueProcessorService implements OnApplicationShutdown {
 			const logger = this.logger.createSubLogger('note-delete');
 			const hooks = makeHooks(logger, 'NoteDelete', 'debug');
 			jobRuntime.handle(noteDeleteJob, wrapProcessor((job) => this.noteDeleteProcessorService.process(job)), { hooks });
+		}
+		//#endregion
+
+		//#region reaction deliver
+		{
+			const logger = this.logger.createSubLogger('reaction-deliver');
+			const hooks = makeHooks(logger, 'ReactionDeliver', 'debug');
+			jobRuntime.handle(reactionDeliverJob, wrapProcessor((job) => this.reactionDeliverProcessorService.process(job)), { hooks });
+		}
+		//#endregion
+
+		//#region note pining deliver
+		{
+			const logger = this.logger.createSubLogger('note-pining-deliver');
+			const hooks = makeHooks(logger, 'NotePiningDeliver', 'debug');
+			jobRuntime.handle(notePiningDeliverJob, wrapProcessor((job) => this.notePiningDeliverProcessorService.process(job)), { hooks });
+		}
+		//#endregion
+
+		//#region instance follow stats update
+		{
+			const logger = this.logger.createSubLogger('instance-follow-stats-update');
+			const hooks = makeHooks(logger, 'InstanceFollowStatsUpdate', 'debug');
+			jobRuntime.handle(instanceFollowStatsUpdateJob, wrapProcessor((job) => this.instanceFollowStatsUpdateProcessorService.process(job)), { hooks });
 		}
 		//#endregion
 

--- a/packages/backend/src/queue/const.ts
+++ b/packages/backend/src/queue/const.ts
@@ -16,6 +16,9 @@ export const QUEUE = {
 	SYSTEM_WEBHOOK_DELIVER: 'systemWebhookDeliver',
 	NOTE_POST: 'notePost',
 	NOTE_DELETE: 'noteDelete',
+	REACTION_DELIVER: 'reactionDeliver',
+	NOTE_PINING_DELIVER: 'notePiningDeliver',
+	INSTANCE_FOLLOW_STATS_UPDATE: 'instanceFollowStatsUpdate',
 } as const;
 
 export const QUEUE_TYPES = Object.values(QUEUE);

--- a/packages/backend/src/queue/jobs/definitions/instanceFollowStatsUpdate.ts
+++ b/packages/backend/src/queue/jobs/definitions/instanceFollowStatsUpdate.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { defineQueueForBullMQ } from '@mokurokujs/bullmq-adapter';
+import { defineJob } from '@mokurokujs/core';
+import { loadConfig } from '@/config.js';
+import { QUEUE } from '@/queue/const.js';
+import { baseQueueOptions, baseWorkerOptions } from '@/queue/helper.js';
+import type { InstanceFollowStatsUpdateJobData } from '@/queue/types.js';
+
+const config = loadConfig();
+
+/** 共通の削除ポリシー */
+const defaultRemovePolicy = {
+	removeOnComplete: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 30,
+	},
+	removeOnFail: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 100,
+	},
+} as const;
+
+export const instanceFollowStatsUpdateQueue = defineQueueForBullMQ(QUEUE.INSTANCE_FOLLOW_STATS_UPDATE, {
+	queueOptions: {
+		...baseQueueOptions(config, QUEUE.INSTANCE_FOLLOW_STATS_UPDATE),
+	},
+	workerOptions: {
+		autorun: false,
+		concurrency: 4,
+		...baseWorkerOptions(config, QUEUE.INSTANCE_FOLLOW_STATS_UPDATE),
+	},
+}).build();
+
+export const instanceFollowStatsUpdateJob = defineJob<InstanceFollowStatsUpdateJobData>('instanceFollowStatsUpdate', {
+	queue: instanceFollowStatsUpdateQueue,
+	attempts: 3,
+	...defaultRemovePolicy,
+});

--- a/packages/backend/src/queue/jobs/definitions/notePiningDeliver.ts
+++ b/packages/backend/src/queue/jobs/definitions/notePiningDeliver.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { defineQueueForBullMQ } from '@mokurokujs/bullmq-adapter';
+import { defineJob } from '@mokurokujs/core';
+import { loadConfig } from '@/config.js';
+import { QUEUE } from '@/queue/const.js';
+import { baseQueueOptions, baseWorkerOptions } from '@/queue/helper.js';
+import type { NotePiningDeliverJobData } from '@/queue/types.js';
+
+const config = loadConfig();
+
+/** 共通の削除ポリシー */
+const defaultRemovePolicy = {
+	removeOnComplete: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 30,
+	},
+	removeOnFail: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 100,
+	},
+} as const;
+
+export const notePiningDeliverQueue = defineQueueForBullMQ(QUEUE.NOTE_PINING_DELIVER, {
+	queueOptions: {
+		...baseQueueOptions(config, QUEUE.NOTE_PINING_DELIVER),
+	},
+	workerOptions: {
+		autorun: false,
+		concurrency: 4,
+		...baseWorkerOptions(config, QUEUE.NOTE_PINING_DELIVER),
+	},
+}).build();
+
+export const notePiningDeliverJob = defineJob<NotePiningDeliverJobData>('notePiningDeliver', {
+	queue: notePiningDeliverQueue,
+	attempts: 2,
+	...defaultRemovePolicy,
+});

--- a/packages/backend/src/queue/jobs/definitions/reactionDeliver.ts
+++ b/packages/backend/src/queue/jobs/definitions/reactionDeliver.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { defineQueueForBullMQ } from '@mokurokujs/bullmq-adapter';
+import { defineJob } from '@mokurokujs/core';
+import { loadConfig } from '@/config.js';
+import { QUEUE } from '@/queue/const.js';
+import { baseQueueOptions, baseWorkerOptions } from '@/queue/helper.js';
+import type { ReactionDeliverJobData } from '@/queue/types.js';
+
+const config = loadConfig();
+
+/** 共通の削除ポリシー */
+const defaultRemovePolicy = {
+	removeOnComplete: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 30,
+	},
+	removeOnFail: {
+		age: 3600 * 24 * 7, // 7 days
+		count: 100,
+	},
+} as const;
+
+export const reactionDeliverQueue = defineQueueForBullMQ(QUEUE.REACTION_DELIVER, {
+	queueOptions: {
+		...baseQueueOptions(config, QUEUE.REACTION_DELIVER),
+	},
+	workerOptions: {
+		autorun: false,
+		concurrency: 4,
+		...baseWorkerOptions(config, QUEUE.REACTION_DELIVER),
+	},
+}).build();
+
+export const reactionDeliverJob = defineJob<ReactionDeliverJobData>('reactionDeliver', {
+	queue: reactionDeliverQueue,
+	attempts: 2,
+	...defaultRemovePolicy,
+});

--- a/packages/backend/src/queue/jobs/queueDefinitions.ts
+++ b/packages/backend/src/queue/jobs/queueDefinitions.ts
@@ -14,6 +14,9 @@ import { objectStorageQueue } from '@/queue/jobs/definitions/objectStorage.js';
 import { systemWebhookDeliverQueue, userWebhookDeliverQueue } from '@/queue/jobs/definitions/webhook.js';
 import { notePostQueue } from '@/queue/jobs/definitions/note.js';
 import { noteDeleteQueue } from '@/queue/jobs/definitions/noteDelete.js';
+import { reactionDeliverQueue } from '@/queue/jobs/definitions/reactionDeliver.js';
+import { notePiningDeliverQueue } from '@/queue/jobs/definitions/notePiningDeliver.js';
+import { instanceFollowStatsUpdateQueue } from '@/queue/jobs/definitions/instanceFollowStatsUpdate.js';
 import type { QueueDefinition } from '@mokurokujs/core';
 
 const definitionsByType: Record<QueueType, QueueDefinition> = {
@@ -29,6 +32,9 @@ const definitionsByType: Record<QueueType, QueueDefinition> = {
 	[QUEUE.SYSTEM_WEBHOOK_DELIVER]: systemWebhookDeliverQueue,
 	[QUEUE.NOTE_POST]: notePostQueue,
 	[QUEUE.NOTE_DELETE]: noteDeleteQueue,
+	[QUEUE.REACTION_DELIVER]: reactionDeliverQueue,
+	[QUEUE.NOTE_PINING_DELIVER]: notePiningDeliverQueue,
+	[QUEUE.INSTANCE_FOLLOW_STATS_UPDATE]: instanceFollowStatsUpdateQueue,
 };
 
 export function queueDefinitionFromType(queueType: QueueType): QueueDefinition {

--- a/packages/backend/src/queue/processors/InstanceFollowStatsUpdateProcessorService.ts
+++ b/packages/backend/src/queue/processors/InstanceFollowStatsUpdateProcessorService.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import * as Bull from 'bullmq';
+import { DI } from '@/di-symbols.js';
+import type { InstancesRepository } from '@/models/_.js';
+import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
+import InstanceChart from '@/core/chart/charts/instance.js';
+import { bindThis } from '@/decorators.js';
+import type Logger from '@/logger.js';
+import type { InstanceFollowStatsUpdateJobData } from '@/queue/types.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+@Injectable()
+export class InstanceFollowStatsUpdateProcessorService {
+	private logger: Logger;
+
+	constructor(
+		@Inject(DI.instancesRepository)
+		private instancesRepository: InstancesRepository,
+
+		private federatedInstanceService: FederatedInstanceService,
+		private instanceChart: InstanceChart,
+		private queueLoggerService: QueueLoggerService,
+	) {
+		this.logger = this.queueLoggerService.logger.createSubLogger('instance-follow-stats-update');
+	}
+
+	@bindThis
+	public async process(job: Bull.Job<InstanceFollowStatsUpdateJobData>): Promise<void> {
+		const { host, direction, isAdditional, updateChart } = job.data;
+
+		const instance = await this.federatedInstanceService.fetchOrRegister(host);
+
+		const column = direction === 'following' ? 'followingCount' : 'followersCount';
+		if (isAdditional) {
+			await this.instancesRepository.increment({ id: instance.id }, column, 1);
+		} else {
+			await this.instancesRepository.decrement({ id: instance.id }, column, 1);
+		}
+
+		if (updateChart) {
+			if (direction === 'following') {
+				await this.instanceChart.updateFollowing(instance.host, isAdditional);
+			} else {
+				await this.instanceChart.updateFollowers(instance.host, isAdditional);
+			}
+		}
+	}
+}

--- a/packages/backend/src/queue/processors/NotePiningDeliverProcessorService.ts
+++ b/packages/backend/src/queue/processors/NotePiningDeliverProcessorService.ts
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable } from '@nestjs/common';
+import * as Bull from 'bullmq';
+import type { MiLocalUser } from '@/models/User.js';
+import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
+import { RelayService } from '@/core/RelayService.js';
+import { bindThis } from '@/decorators.js';
+import type { NotePiningDeliverJobData } from '@/queue/types.js';
+import type Logger from '@/logger.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+@Injectable()
+export class NotePiningDeliverProcessorService {
+	private logger: Logger;
+
+	constructor(
+		private apDeliverManagerService: ApDeliverManagerService,
+		private relayService: RelayService,
+		private queueLoggerService: QueueLoggerService,
+	) {
+		this.logger = this.queueLoggerService.logger.createSubLogger('note-pining-deliver');
+	}
+
+	@bindThis
+	public async process(job: Bull.Job<NotePiningDeliverJobData>): Promise<void> {
+		const { userSnapshot, apContent } = job.data;
+
+		if (apContent == null) return;
+
+		const localUser = { id: userSnapshot.id, host: null as null } as unknown as MiLocalUser;
+
+		await Promise.all([
+			this.apDeliverManagerService.deliverToFollowers(localUser, apContent),
+			this.relayService.deliverToRelays(localUser, apContent),
+		]);
+	}
+}

--- a/packages/backend/src/queue/processors/ReactionDeliverProcessorService.ts
+++ b/packages/backend/src/queue/processors/ReactionDeliverProcessorService.ts
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import { In } from 'typeorm';
+import * as Bull from 'bullmq';
+import type { UsersRepository } from '@/models/_.js';
+import type { MiLocalUser, MiRemoteUser } from '@/models/User.js';
+import { DI } from '@/di-symbols.js';
+import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerService.js';
+import { bindThis } from '@/decorators.js';
+import type { ReactionDeliverJobData } from '@/queue/types.js';
+import type Logger from '@/logger.js';
+import { QueueLoggerService } from '@/queue/QueueLoggerService.js';
+
+@Injectable()
+export class ReactionDeliverProcessorService {
+	private logger: Logger;
+
+	constructor(
+		@Inject(DI.usersRepository)
+		private usersRepository: UsersRepository,
+
+		private apDeliverManagerService: ApDeliverManagerService,
+		private queueLoggerService: QueueLoggerService,
+	) {
+		this.logger = this.queueLoggerService.logger.createSubLogger('reaction-deliver');
+	}
+
+	@bindThis
+	public async process(job: Bull.Job<ReactionDeliverJobData>): Promise<void> {
+		const { userSnapshot, apContent, apRecipientIds, deliverToFollowers } = job.data;
+
+		if (apContent === null) return;
+
+		const localUser = { id: userSnapshot.id, host: null as null } as unknown as MiLocalUser;
+		const dm = this.apDeliverManagerService.createDeliverManager(localUser, apContent);
+
+		if (apRecipientIds.length > 0) {
+			const recipients = await this.usersRepository.findBy({ id: In(apRecipientIds) }) as MiRemoteUser[];
+			for (const recipient of recipients) {
+				dm.addDirectRecipe(recipient);
+			}
+		}
+
+		if (deliverToFollowers) {
+			dm.addFollowersRecipe();
+		}
+
+		await dm.execute();
+	}
+}

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -128,6 +128,37 @@ export type NoteDeleteJobData = {
 	isRemote: boolean;
 };
 
+export type ReactionDeliverJobData = {
+	noteId: string;
+	userSnapshot: { id: string };
+	apContent: any | null;
+	apRecipientIds: string[];
+	isUndo: boolean;
+	/** addFollowersRecipe を呼ぶかどうか (HTTP 側で visibility / undo から判定して渡す) */
+	deliverToFollowers: boolean;
+};
+
+export type NotePiningDeliverJobData = {
+	noteId: string;
+	userSnapshot: { id: string };
+	apContent: any | null;
+	isAddition: boolean;
+};
+
+/**
+ * リモートインスタンスの follow/follower カウンタおよび instance chart を更新するジョブのペイロード。
+ *
+ * - direction: 'following' を指定すると `instances.followingCount` を、'followers' を指定すると `followersCount` を更新する。
+ * - isAdditional: true で increment / false で decrement。
+ * - updateChart: enqueue 時点で `meta.enableChartsForFederatedInstances` を判定して保持する。
+ */
+export type InstanceFollowStatsUpdateJobData = {
+	host: string;
+	direction: 'following' | 'followers';
+	isAdditional: boolean;
+	updateChart: boolean;
+};
+
 export type UpdateUserNotesCountJobData = {
 	userId: string;
 };


### PR DESCRIPTION
## 機能の説明

ノート投稿以外の細かい処理についても、サービス層から同期実行していた重めの後処理をジョブキュー経由に移しました。

ジョブ化対象:

- **リアクション配信** (`ReactionDeliverProcessorService`) — `ReactionService` から切り出し
- **ノートピン留め配信** (`NotePiningDeliverProcessorService`) — `NotePiningService` から切り出し
- **インスタンスごとのフォロー数統計更新** (`InstanceFollowStatsUpdateProcessorService`) — `UserFollowingService` から切り出し

これらは `QueueService` 経由でジョブを enqueue し、`QueueProcessorService` 上で非同期実行されます。

## 利点

- 同期処理が残っていたサービス層から、配信・統計更新を切り離してレスポンス時間を改善
- リアクション・ピン留め・フォロー操作の API がより素早く完了する
- 失敗時のリトライがジョブキュー基盤に乗り、観測性・耐障害性が向上
- #92 (ノート投稿後処理の JobQueue 化) と合わせ、tiramiss バックエンドの "重い処理は基本キュー経由" 方針を完成させる位置付け