### PR TITLE
[機能紹介] 過去タイムラインウィンドウ

### DIFF
--- a/packages/frontend/src/components/MkPastTimelineWindow.vue
+++ b/packages/frontend/src/components/MkPastTimelineWindow.vue
@@ -1,0 +1,91 @@
+<!--
+SPDX-FileCopyrightText: syuilo and misskey-project
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<template>
+<MkWindow
+	:initialWidth="520"
+	:initialHeight="700"
+	:canResize="true"
+	:closeButton="true"
+	@closed="emit('closed')"
+>
+	<template #header>
+		<i class="ti ti-calendar-time" style="margin-right: 0.5em;"></i>
+		<span>{{ title }}</span>
+	</template>
+
+	<div :class="$style.root">
+		<div :class="$style.notice">
+			<i class="ti ti-info-circle"></i>
+			<span>{{ i18n.ts.showingPastTimeline }}</span>
+		</div>
+		<MkStreamingNotesTimeline
+			:src="src"
+			:list="list"
+			:antenna="antenna"
+			:channel="channel"
+			:withRenotes="withRenotes"
+			:withReplies="withReplies"
+			:withSensitive="withSensitive"
+			:withLocalOnly="withLocalOnly"
+			:onlyFiles="onlyFiles"
+			:initialDate="initialDate"
+			:disableRealtime="true"
+			:sound="false"
+		/>
+	</div>
+</MkWindow>
+</template>
+
+<script lang="ts" setup>
+import type { BasicTimelineType } from '@/timelines.js';
+import MkStreamingNotesTimeline from '@/components/MkStreamingNotesTimeline.vue';
+import MkWindow from '@/components/MkWindow.vue';
+import { i18n } from '@/i18n.js';
+
+withDefaults(defineProps<{
+	src: BasicTimelineType | 'list' | 'antenna' | 'channel';
+	initialDate: number;
+	title: string;
+	list?: string;
+	antenna?: string;
+	channel?: string;
+	withRenotes?: boolean;
+	withReplies?: boolean;
+	withSensitive?: boolean;
+	withLocalOnly?: boolean;
+	onlyFiles?: boolean;
+}>(), {
+	list: undefined,
+	antenna: undefined,
+	channel: undefined,
+	withRenotes: true,
+	withReplies: true,
+	withSensitive: true,
+	withLocalOnly: true,
+	onlyFiles: false,
+});
+
+const emit = defineEmits<{
+	(ev: 'closed'): void;
+}>();
+</script>
+
+<style lang="scss" module>
+.root {
+	min-height: 100%;
+	background: var(--MI_THEME-bg);
+}
+
+.notice {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	padding: 10px 12px;
+	color: var(--MI_THEME-fg);
+	background: var(--MI_THEME-panel);
+	border-bottom: solid 0.5px var(--MI_THEME-divider);
+}
+</style>

--- a/packages/frontend/src/components/MkStreamingNotesTimeline.vue
+++ b/packages/frontend/src/components/MkStreamingNotesTimeline.vue
@@ -19,8 +19,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<div :class="$style.newBg2"></div>
 			<button class="_button" :class="$style.newButton" @click="releaseQueue()"><i class="ti ti-circle-arrow-up"></i> {{ i18n.ts.newNote }}</button>
 		</div>
+		<button v-show="fixedPastTimeline && paginator.canFetchNewer.value && paginator.items.value.length > 0" key="_more_newer_" :disabled="paginator.fetchingNewer.value" class="_button" :class="$style.more" @click="fetchNewerPreservingScroll()">
+			<div v-if="!paginator.fetchingNewer.value">{{ i18n.ts.loadMore }}</div>
+			<MkLoading v-else :inline="true"/>
+		</button>
 		<component
-			:is="prefer.s.animation ? TransitionGroup : 'div'"
+			:is="useNoteTransition ? TransitionGroup : 'div'"
 			:class="$style.notes"
 			:enterActiveClass="$style.transition_x_enterActive"
 			:leaveActiveClass="$style.transition_x_leaveActive"
@@ -56,7 +60,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { computed, watch, onUnmounted, provide, useTemplateRef, TransitionGroup, onMounted, shallowRef, ref, markRaw } from 'vue';
+import { computed, watch, onUnmounted, provide, useTemplateRef, TransitionGroup, onMounted, shallowRef, ref, markRaw, nextTick } from 'vue';
 import * as Misskey from 'misskey-js';
 import { useInterval } from '@@/js/use-interval.js';
 import { useDocumentVisibility } from '@@/js/use-document-visibility.js';
@@ -91,6 +95,8 @@ const props = withDefaults(defineProps<{
 	withReplies?: boolean;
 	withSensitive?: boolean;
 	onlyFiles?: boolean;
+	initialDate?: number | null;
+	disableRealtime?: boolean;
 }>(), {
 	withRenotes: true,
 	withReplies: false,
@@ -98,11 +104,15 @@ const props = withDefaults(defineProps<{
 	onlyFiles: false,
 	sound: false,
 	customSound: null,
+	initialDate: null,
+	disableRealtime: false,
 });
 
 provide('inTimeline', true);
 provide('tl_withSensitive', computed(() => props.withSensitive));
 provide(DI.inChannel, computed(() => props.src === 'channel' ? props.channel ?? null : null));
+const fixedPastTimeline = computed(() => props.disableRealtime && props.initialDate != null);
+const useNoteTransition = computed(() => prefer.s.animation && !fixedPastTimeline.value);
 
 let paginator: IPaginator<Misskey.entities.Note>;
 
@@ -111,6 +121,7 @@ if (props.src === 'antenna') {
 		computedParams: computed(() => ({
 			antennaId: props.antenna!,
 		})),
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'home') {
@@ -119,6 +130,7 @@ if (props.src === 'antenna') {
 			withRenotes: props.withRenotes,
 			withFiles: props.onlyFiles ? true : undefined,
 		})),
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'local') {
@@ -128,6 +140,7 @@ if (props.src === 'antenna') {
 			withReplies: props.withReplies,
 			withFiles: props.onlyFiles ? true : undefined,
 		})),
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'social') {
@@ -137,6 +150,7 @@ if (props.src === 'antenna') {
 			withReplies: props.withReplies,
 			withFiles: props.onlyFiles ? true : undefined,
 		})),
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'global') {
@@ -145,10 +159,12 @@ if (props.src === 'antenna') {
 			withRenotes: props.withRenotes,
 			withFiles: props.onlyFiles ? true : undefined,
 		})),
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'mentions') {
 	paginator = markRaw(new Paginator('notes/mentions', {
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'directs') {
@@ -156,6 +172,7 @@ if (props.src === 'antenna') {
 		params: {
 			visibility: 'specified',
 		},
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'list') {
@@ -165,6 +182,7 @@ if (props.src === 'antenna') {
 			withFiles: props.onlyFiles ? true : undefined,
 			listId: props.list!,
 		})),
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'channel') {
@@ -172,6 +190,7 @@ if (props.src === 'antenna') {
 		computedParams: computed(() => ({
 			channelId: props.channel!,
 		})),
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else if (props.src === 'role') {
@@ -179,6 +198,7 @@ if (props.src === 'antenna') {
 		computedParams: computed(() => ({
 			roleId: props.role!,
 		})),
+		initialDate: props.initialDate,
 		useShallowRef: true,
 	}));
 } else {
@@ -249,7 +269,7 @@ const POLLING_INTERVAL =
 	prefer.s.pollingInterval === 3 ? MIN_POLLING_INTERVAL :
 	MIN_POLLING_INTERVAL;
 
-if (!store.s.realtimeMode) {
+if (!props.disableRealtime && !store.s.realtimeMode) {
 	// TODO: 先頭のノートの作成日時が1日以上前であれば流速が遅いTLと見做してインターバルを通常より延ばす
 	useInterval(async () => {
 		paginator.fetchNewer({
@@ -267,13 +287,45 @@ if (!store.s.realtimeMode) {
 	});
 }
 
-useGlobalEvent('noteDeleted', (noteId) => {
-	paginator.removeItem(noteId);
-});
+if (!props.disableRealtime) {
+	useGlobalEvent('noteDeleted', (noteId) => {
+		paginator.removeItem(noteId);
+	});
+}
 
 function releaseQueue() {
 	paginator.releaseQueue();
 	scrollToTop(rootEl.value!);
+}
+
+function captureScrollSnapshot(): { top: number; height: number; } | null {
+	if (rootEl.value == null) return null;
+
+	if (scrollContainer) {
+		return {
+			top: scrollContainer.scrollTop,
+			height: scrollContainer.scrollHeight,
+		};
+	}
+
+	return {
+		top: window.scrollY,
+		height: window.document.documentElement.scrollHeight,
+	};
+}
+
+async function fetchNewerPreservingScroll() {
+	const snapshot = captureScrollSnapshot();
+	await paginator.fetchNewer();
+	await nextTick();
+
+	if (snapshot == null) return;
+
+	if (scrollContainer) {
+		scrollContainer.scrollTop = snapshot.top + (scrollContainer.scrollHeight - snapshot.height);
+	} else {
+		window.scrollTo(window.scrollX, snapshot.top + (window.document.documentElement.scrollHeight - snapshot.height));
+	}
 }
 
 function prepend(note: Misskey.entities.Note & MisskeyEntity) {
@@ -298,7 +350,7 @@ function prepend(note: Misskey.entities.Note & MisskeyEntity) {
 	}
 }
 
-const stream = store.s.realtimeMode ? useStream() : null;
+const stream = !props.disableRealtime && store.s.realtimeMode ? useStream() : null;
 
 const connections = {
 	antenna: null as Misskey.IChannelConnection<Misskey.Channels['antenna']> | null,
@@ -390,12 +442,12 @@ function disconnectChannel() {
 	}
 }
 
-if (store.s.realtimeMode) {
+if (!props.disableRealtime && store.s.realtimeMode) {
 	connectChannel();
 }
 
 watch(() => [props.list, props.antenna, props.channel, props.role, props.withRenotes], () => {
-	if (store.s.realtimeMode) {
+	if (!props.disableRealtime && store.s.realtimeMode) {
 		disconnectChannel();
 		connectChannel();
 	}

--- a/packages/frontend/src/pages/antenna-timeline.vue
+++ b/packages/frontend/src/pages/antenna-timeline.vue
@@ -27,6 +27,7 @@ import { misskeyApi } from '@/utility/misskey-api.js';
 import { definePage } from '@/page.js';
 import { i18n } from '@/i18n.js';
 import { useRouter } from '@/router.js';
+import { openPastTimelineWindow } from '@/ui/deck/past-timeline-window.js';
 
 const router = useRouter();
 
@@ -45,6 +46,14 @@ function settings() {
 	});
 }
 
+function openPastTimeline() {
+	void openPastTimelineWindow({
+		src: 'antenna',
+		title: antenna.value?.name ?? i18n.ts.antennas,
+		antenna: props.antennaId,
+	});
+}
+
 watch(() => props.antennaId, async () => {
 	antenna.value = await misskeyApi('antennas/show', {
 		antennaId: props.antennaId,
@@ -55,6 +64,10 @@ const headerActions = computed(() => antenna.value ? [{
 	icon: 'ti ti-settings',
 	text: i18n.ts.settings,
 	handler: settings,
+}, {
+	icon: 'ti ti-calendar-time',
+	text: i18n.ts.jumpToSpecifiedDate,
+	handler: openPastTimeline,
 }] : []);
 
 const headerTabs = computed(() => []);

--- a/packages/frontend/src/pages/channel.vue
+++ b/packages/frontend/src/pages/channel.vue
@@ -99,6 +99,7 @@ import { notesSearchAvailable } from '@/utility/check-permissions.js';
 import { miLocalStorage } from '@/local-storage.js';
 import { useRouter } from '@/router.js';
 import { Paginator } from '@/utility/paginator.js';
+import { openPastTimelineWindow } from '@/ui/deck/past-timeline-window.js';
 
 const router = useRouter();
 
@@ -161,6 +162,16 @@ function edit() {
 function openPostForm() {
 	os.post({
 		channel: channel.value,
+	});
+}
+
+function openPastTimeline() {
+	if (!channel.value) return;
+
+	void openPastTimelineWindow({
+		src: 'channel',
+		title: channel.value.name,
+		channel: channel.value.id,
 	});
 }
 
@@ -270,6 +281,12 @@ const headerActions = computed(() => {
 				}
 				copyToClipboard(`${url}/channels/${channel.value.id}`);
 			},
+		});
+
+		headerItems.push({
+			icon: 'ti ti-calendar-time',
+			text: i18n.ts.jumpToSpecifiedDate,
+			handler: openPastTimeline,
 		});
 
 		if (isSupportShare()) {

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -45,6 +45,7 @@ import { deepMerge } from '@/utility/merge.js';
 import { miLocalStorage } from '@/local-storage.js';
 import { availableBasicTimelines, hasWithReplies, isAvailableBasicTimeline, isBasicTimeline, basicTimelineIconClass } from '@/timelines.js';
 import { prefer } from '@/preferences.js';
+import { openPastTimelineWindow } from '@/ui/deck/past-timeline-window.js';
 
 const tlComponent = useTemplateRef('tlComponent');
 
@@ -197,6 +198,33 @@ function switchTlIfNeeded() {
 	}
 }
 
+function openPastTimeline() {
+	const currentSrc = src.value;
+
+	if (isBasicTimeline(currentSrc)) {
+		void openPastTimelineWindow({
+			src: currentSrc,
+			title: i18n.ts._timelines[currentSrc],
+			withRenotes: withRenotes.value,
+			withReplies: withReplies.value,
+			withSensitive: withSensitive.value,
+			withLocalOnly: withLocalOnly.value,
+			onlyFiles: onlyFiles.value,
+		});
+	} else if (currentSrc.startsWith('list:')) {
+		const listId = currentSrc.substring('list:'.length);
+		const list = prefer.r.pinnedUserLists.value.find(x => x.id === listId);
+		void openPastTimelineWindow({
+			src: 'list',
+			title: list?.name ?? i18n.ts.lists,
+			list: listId,
+			withRenotes: withRenotes.value,
+			withSensitive: withSensitive.value,
+			onlyFiles: onlyFiles.value,
+		});
+	}
+}
+
 onMounted(() => {
 	switchTlIfNeeded();
 });
@@ -260,6 +288,12 @@ const headerActions = computed<PageHeaderItem[]>(() => {
 			},
 		});
 	}
+
+	items.unshift({
+		icon: 'ti ti-calendar-time',
+		text: i18n.ts.jumpToSpecifiedDate,
+		handler: openPastTimeline,
+	});
 
 	return items;
 });

--- a/packages/frontend/src/pages/user-list-timeline.vue
+++ b/packages/frontend/src/pages/user-list-timeline.vue
@@ -26,6 +26,7 @@ import { misskeyApi } from '@/utility/misskey-api.js';
 import { definePage } from '@/page.js';
 import { i18n } from '@/i18n.js';
 import { useRouter } from '@/router.js';
+import { openPastTimelineWindow } from '@/ui/deck/past-timeline-window.js';
 
 const router = useRouter();
 
@@ -49,10 +50,22 @@ function settings() {
 	});
 }
 
+function openPastTimeline() {
+	void openPastTimelineWindow({
+		src: 'list',
+		title: list.value?.name ?? i18n.ts.lists,
+		list: props.listId,
+	});
+}
+
 const headerActions = computed(() => list.value ? [{
 	icon: 'ti ti-settings',
 	text: i18n.ts.settings,
 	handler: settings,
+}, {
+	icon: 'ti ti-calendar-time',
+	text: i18n.ts.jumpToSpecifiedDate,
+	handler: openPastTimeline,
 }] : []);
 
 const headerTabs = computed(() => []);

--- a/packages/frontend/src/ui/deck/antenna-column.vue
+++ b/packages/frontend/src/ui/deck/antenna-column.vue
@@ -27,6 +27,7 @@ import { misskeyApi } from '@/utility/misskey-api.js';
 import { i18n } from '@/i18n.js';
 import { antennasCache } from '@/cache.js';
 import { soundSettingsButton } from '@/ui/deck/tl-note-notification.js';
+import { openPastTimelineWindow } from '@/ui/deck/past-timeline-window.js';
 
 const props = defineProps<{
 	column: Column;
@@ -96,6 +97,16 @@ function editAntenna() {
 	os.pageWindow('/my/antennas/' + props.column.antennaId);
 }
 
+function openPastTimeline() {
+	if (props.column.antennaId == null) return;
+
+	void openPastTimelineWindow({
+		src: 'antenna',
+		title: props.column.name || props.column.timelineNameCache || i18n.ts._deck._columns.antenna,
+		antenna: props.column.antennaId,
+	});
+}
+
 const menu: MenuItem[] = [
 	{
 		icon: 'ti ti-pencil',
@@ -111,6 +122,11 @@ const menu: MenuItem[] = [
 		icon: 'ti ti-bell',
 		text: i18n.ts._deck.newNoteNotificationSettings,
 		action: () => soundSettingsButton(soundSetting),
+	},
+	{
+		icon: 'ti ti-calendar-time',
+		text: i18n.ts.jumpToSpecifiedDate,
+		action: openPastTimeline,
 	},
 ];
 

--- a/packages/frontend/src/ui/deck/channel-column.vue
+++ b/packages/frontend/src/ui/deck/channel-column.vue
@@ -33,6 +33,7 @@ import { favoritedChannelsCache } from '@/cache.js';
 import { misskeyApi } from '@/utility/misskey-api.js';
 import { i18n } from '@/i18n.js';
 import { soundSettingsButton } from '@/ui/deck/tl-note-notification.js';
+import { openPastTimelineWindow } from '@/ui/deck/past-timeline-window.js';
 
 const props = defineProps<{
 	column: Column;
@@ -86,6 +87,16 @@ async function post() {
 	});
 }
 
+function openPastTimeline() {
+	if (props.column.channelId == null) return;
+
+	void openPastTimelineWindow({
+		src: 'channel',
+		title: props.column.name || props.column.timelineNameCache || i18n.ts._deck._columns.channel,
+		channel: props.column.channelId,
+	});
+}
+
 const menu: MenuItem[] = [{
 	icon: 'ti ti-pencil',
 	text: i18n.ts.selectChannel,
@@ -94,5 +105,9 @@ const menu: MenuItem[] = [{
 	icon: 'ti ti-bell',
 	text: i18n.ts._deck.newNoteNotificationSettings,
 	action: () => soundSettingsButton(soundSetting),
+}, {
+	icon: 'ti ti-calendar-time',
+	text: i18n.ts.jumpToSpecifiedDate,
+	action: openPastTimeline,
 }];
 </script>

--- a/packages/frontend/src/ui/deck/list-column.vue
+++ b/packages/frontend/src/ui/deck/list-column.vue
@@ -27,6 +27,7 @@ import { misskeyApi } from '@/utility/misskey-api.js';
 import { i18n } from '@/i18n.js';
 import { userListsCache } from '@/cache.js';
 import { soundSettingsButton } from '@/ui/deck/tl-note-notification.js';
+import { openPastTimelineWindow } from '@/ui/deck/past-timeline-window.js';
 
 const props = defineProps<{
 	column: Column;
@@ -101,6 +102,17 @@ function editList() {
 	os.pageWindow('/my/lists/' + props.column.listId);
 }
 
+function openPastTimeline() {
+	if (props.column.listId == null) return;
+
+	void openPastTimelineWindow({
+		src: 'list',
+		title: props.column.name || props.column.timelineNameCache || i18n.ts._deck._columns.list,
+		list: props.column.listId,
+		withRenotes: withRenotes.value,
+	});
+}
+
 const menu: MenuItem[] = [
 	{
 		icon: 'ti ti-pencil',
@@ -121,6 +133,11 @@ const menu: MenuItem[] = [
 		icon: 'ti ti-bell',
 		text: i18n.ts._deck.newNoteNotificationSettings,
 		action: () => soundSettingsButton(soundSetting),
+	},
+	{
+		icon: 'ti ti-calendar-time',
+		text: i18n.ts.jumpToSpecifiedDate,
+		action: openPastTimeline,
 	},
 ];
 </script>

--- a/packages/frontend/src/ui/deck/past-timeline-window.ts
+++ b/packages/frontend/src/ui/deck/past-timeline-window.ts
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { defineAsyncComponent } from 'vue';
+import type { BasicTimelineType } from '@/timelines.js';
+import * as os from '@/os.js';
+import { i18n } from '@/i18n.js';
+
+export type PastTimelineWindowOptions = {
+	src: BasicTimelineType | 'list' | 'antenna' | 'channel';
+	title: string;
+	list?: string;
+	antenna?: string;
+	channel?: string;
+	withRenotes?: boolean;
+	withReplies?: boolean;
+	withSensitive?: boolean;
+	withLocalOnly?: boolean;
+	onlyFiles?: boolean;
+};
+
+function pad2(value: number): string {
+	return value.toString().padStart(2, '0');
+}
+
+export function formatDatetimeLocal(date: Date): string {
+	return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+}
+
+export async function openPastTimelineWindow(options: PastTimelineWindowOptions): Promise<void> {
+	const { canceled, result } = await os.inputDatetime({
+		title: i18n.ts.jumpToSpecifiedDate,
+		default: formatDatetimeLocal(new Date()),
+	});
+	if (canceled || result == null) return;
+
+	const initialDate = result.getTime();
+	if (Number.isNaN(initialDate)) return;
+
+	const { dispose } = os.popup(defineAsyncComponent(() => import('@/components/MkPastTimelineWindow.vue')), {
+		...options,
+		initialDate,
+	}, {
+		closed: () => dispose(),
+	});
+}

--- a/packages/frontend/src/ui/deck/tl-column.vue
+++ b/packages/frontend/src/ui/deck/tl-column.vue
@@ -44,6 +44,7 @@ import * as os from '@/os.js';
 import { i18n } from '@/i18n.js';
 import { hasWithReplies, isAvailableBasicTimeline, basicTimelineIconClass } from '@/timelines.js';
 import { soundSettingsButton } from '@/ui/deck/tl-note-notification.js';
+import { openPastTimelineWindow } from '@/ui/deck/past-timeline-window.js';
 
 const props = defineProps<{
 	column: Column;
@@ -118,6 +119,20 @@ async function setType() {
 	});
 }
 
+function openPastTimeline() {
+	if (props.column.tl == null || !isAvailableBasicTimeline(props.column.tl)) return;
+
+	void openPastTimelineWindow({
+		src: props.column.tl,
+		title: props.column.name || i18n.ts._timelines[props.column.tl],
+		withRenotes: withRenotes.value,
+		withReplies: withReplies.value,
+		withSensitive: withSensitive.value,
+		withLocalOnly: withLocalOnly.value,
+		onlyFiles: onlyFiles.value,
+	});
+}
+
 const menu = computed<MenuItem[]>(() => {
 	const menuItems: MenuItem[] = [];
 
@@ -129,7 +144,17 @@ const menu = computed<MenuItem[]>(() => {
 		icon: 'ti ti-bell',
 		text: i18n.ts._deck.newNoteNotificationSettings,
 		action: () => soundSettingsButton(soundSetting),
-	}, {
+	});
+
+	if (props.column.tl != null && isAvailableBasicTimeline(props.column.tl)) {
+		menuItems.push({
+			icon: 'ti ti-calendar-time',
+			text: i18n.ts.jumpToSpecifiedDate,
+			action: openPastTimeline,
+		});
+	}
+
+	menuItems.push({
 		type: 'switch',
 		text: i18n.ts.showRenotes,
 		ref: withRenotes,

--- a/packages/frontend/src/utility/paginator.ts
+++ b/packages/frontend/src/utility/paginator.ts
@@ -249,6 +249,10 @@ export class Paginator<
 			}
 		}
 
+		if ((this.initialId || this.initialDate) && this.initialDirection === 'older' && !this.noPaging) {
+			this.canFetchNewer.value = apiRes.length > 0;
+		}
+
 		this.error.value = false;
 		this.fetching.value = false;
 	}

--- a/packages/frontend/test/deck-past-timeline.test.ts
+++ b/packages/frontend/test/deck-past-timeline.test.ts
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatDatetimeLocal } from '@/ui/deck/past-timeline-window.js';
+
+describe('deck past timeline window', () => {
+	it('formats a Date for datetime-local input using local time', () => {
+		const date = new Date(2026, 4, 9, 8, 7, 6);
+
+		expect(formatDatetimeLocal(date)).toBe('2026-05-09T08:07');
+	});
+});


### PR DESCRIPTION
## 機能の説明

タイムライン (LTL / HTL / STL / GTL / リスト / アンテナ / チャンネル) を **指定日時の時点に遡って閲覧できるウィンドウ** を追加しました。
タイムライン画面とデッキカラムのメニューから「指定日時へジャンプ」を選び、見たい日時を指定するとその時刻のタイムラインを別ウィンドウで表示します。

主な追加点:

- 新規コンポーネント `MkPastTimelineWindow.vue`
- デッキカラム (`tl-column.vue` / `antenna-column.vue` / `channel-column.vue` / `list-column.vue`) のメニューに導線追加
- 通常画面 (`timeline.vue` / `antenna-timeline.vue` / `channel.vue` / `user-list-timeline.vue`) からも開ける
- `MkStreamingNotesTimeline` を拡張し、`initialDate` / `disableRealtime` で過去時点読み込みに対応
- `paginator.ts` を拡張して開始日時指定を可能に

過去側へのスクロールで連続的に古いノートを辿れ、リアルタイム更新は無効化されるため当時の状態をそのまま閲覧できます。

## 利点

- 「あの日のタイムラインをもう一度見たい」というユースケースに直接応える
- イベント発生時刻を起点に当時の会話・反応を辿りやすい
- 通常タイムラインを汚さず、独立ウィンドウで閲覧できる
- デッキ・通常ビュー両方からアクセス可能で導線が一貫している

関連: #1 「特定の時点のタイムラインを見る機能」 への回答実装